### PR TITLE
[BE-3] Updating saved directory behavior

### DIFF
--- a/beat-editor/server/app.js
+++ b/beat-editor/server/app.js
@@ -20,10 +20,13 @@ app.get('/fetch-file', async (req, res) => {
     const savedDir = path.join(__dirname, '..', 'saved');
     try {
         const dataFiles = await fs.promises.readdir(dataDir);
-        const savedFiles = await fs.promises.readdir(savedDir);
-
         const fileDirJsonFiles = dataFiles.filter(file => file.endsWith('_edit.json'));
-        const savedDirJsonFiles = savedFiles.filter(file => file.endsWith('_edited.json'));
+        
+        // Skip the /saved folder if it doesn't exist
+        const savedFiles = fs.existsSync(savedDir) ? await fs.promises.readdir(savedDir): [];
+        const savedDirJsonFiles = fs.existsSync(savedDir)
+          ? savedFiles.filter((file) => file.endsWith("_edited.json"))
+          : [];
 
         if (dataFiles.length === 0) {
             return res.status(404).send("No JSON files found.");
@@ -61,6 +64,12 @@ app.get('/fetch-file', async (req, res) => {
 // Endpoint for saving JSON file
 app.post('/saved', async (req, res) => {
     const { fileName, data } = req.body;
+    const savedFilePath = path.join(__dirname, "..", "saved");
+    // Checks if /saved exists, if not make it
+    if (!fs.existsSync(savedFilePath)) {
+        fs.mkdirSync(savedFilePath);
+    }
+
     const filePath = path.join(__dirname, '..', 'saved', `${fileName}_edited.json`);
 
     try {


### PR DESCRIPTION
Changed the behavior of how the beat editor loads up and finds the `saved` directory.

1. Users can save files on their end without a `saved` directory - the backend should automatically generate a folder to store the saved edits.
2. Backend was previously grabbing from both the `saved` and `data` directory. Updated the logic to skip scanning and fetching from there if it doesn't exist.

