### PR TITLE
[BE-4] Inconsistent beat rendering and signal label in legend

### DIFF
--- a/beat-editor/src/components/BeatChart.js
+++ b/beat-editor/src/components/BeatChart.js
@@ -38,7 +38,7 @@ const BeatChart = ({
   unusableBeats = [],
 }) => {
   const [chartOptions, setChartOptions] = useState(null);
-  const [ecgData, setECGData] = useState([]);
+  const [cardiacData, setCardiacData] = useState([]);
   const [beatData, setBeatData] = useState([]);
   const [beatArtifactData, setBeatArtifactData] = useState([]);
   const [isAddMode, setIsAddMode] = useState(false);
@@ -98,7 +98,7 @@ const BeatChart = ({
       const artifactX = artifactData.map((o) => o[dataTypeX]);
       const artifactY = artifactData.map((o) => o[dataTypeY]);
 
-      const initECGsData = xAxisData.map((dataType, index) => ({
+      const initCardiacData = xAxisData.map((dataType, index) => ({
         x: dataType,
         y: yAxisData[index],
       }));
@@ -124,7 +124,7 @@ const BeatChart = ({
 
       const chartParams = createChartOptions({
         xAxisData: segmentFilteredData.map((o) => o.Timestamp),
-        initECGsData,
+        initCardiacData,
         initBeats,
         initArtifacts,
         addModeCoordinates,
@@ -141,7 +141,7 @@ const BeatChart = ({
 
       setChartOptions(chartParams);
 
-      setECGData(initECGsData);
+      setCardiacData(initCardiacData);
       setBeatData(initBeats);
       setBeatArtifactData(initArtifacts);
     }
@@ -156,8 +156,8 @@ const BeatChart = ({
     isMarkingUnusableMode,
   ]);
 
-  segmentBoundaries.from = ecgData[0];
-  segmentBoundaries.to = ecgData[ecgData.length - 1];
+  segmentBoundaries.from = cardiacData[0];
+  segmentBoundaries.to = cardiacData[cardiacData.length - 1];
 
   const handleChartClick = (event) => {
     // Prevents coordinates from plotting when hitting `Reset Zoom`
@@ -176,8 +176,8 @@ const BeatChart = ({
       ? event.point.y
       : event.yAxis[0].value;
 
-    // Check if the point already exists in ecgData (for Add Mode) or beatData (for Delete Mode)
-    const isECGCoordinate = ecgData.some(
+    // Check if the point already exists in cardiacData (for Add Mode) or beatData (for Delete Mode)
+    const isSignal = cardiacData.some(
       (point) => point.x === newX && point.y === newY
     );
     const isBeatCoordinate = beatData.some(
@@ -187,8 +187,8 @@ const BeatChart = ({
       (point) => point.x === newX && point.y === newY
     );
 
-    // In Add Mode, prevent adding points that already exist in ecgData
-    if (isPanningRef.current && isAddMode && isECGCoordinate) {
+    // In Add Mode, prevent adding points that already exist in cardiacData
+    if (isPanningRef.current && isAddMode && isSignal) {
       return;
     }
     // In Delete Mode, prevent deleting points that don't exist in beatData or are artifacts
@@ -201,7 +201,7 @@ const BeatChart = ({
       return;
     }
 
-    const updatedECGData = [...ecgData, { x: newX, y: newY }];
+    const updatedCardiacData = [...cardiacData, { x: newX, y: newY }];
     const updatedBeatData = [...beatData];
     const updateArtifactData = [...beatArtifactData];
 
@@ -227,7 +227,7 @@ const BeatChart = ({
       }
     }
 
-    setECGData(updatedECGData);
+    setCardiacData(updatedCardiacData);
     setBeatData(updatedBeatData);
     setBeatArtifactData(updateArtifactData);
   };

--- a/beat-editor/src/components/BeatChart.js
+++ b/beat-editor/src/components/BeatChart.js
@@ -103,13 +103,19 @@ const BeatChart = ({
         y: yAxisData[index],
       }));
 
+      // Checks if correctedAnnotatedData or beatAnnotatedData has the key 'Filtered'
+      const hasFilteredKey = (data) => "Filtered" in data;
+
       const initBeats =
         correctedAnnotatedData.length > 0
           ? correctedAnnotatedData.map((o) => ({
               x: o.Timestamp,
-              y: o.Filtered,
+              y: hasFilteredKey(o) ? o.Filtered : o.Signal,
             }))
-          : beatAnnotatedData.map((o) => ({ x: o.Timestamp, y: o.Filtered }));
+          : beatAnnotatedData.map((o) => ({
+              x: o.Timestamp,
+              y: hasFilteredKey(o) ? o.Filtered : o.Signal,
+            }));
 
       const initArtifacts = artifactX.map((artifactX, index) => ({
         x: artifactX,

--- a/beat-editor/src/components/ChartOptions.js
+++ b/beat-editor/src/components/ChartOptions.js
@@ -1,6 +1,6 @@
 const createChartOptions = ({
     xAxisData,
-    initECGsData,
+    initCardiacData,
     initBeats,
     initArtifacts,
     addModeCoordinates,
@@ -76,7 +76,7 @@ const createChartOptions = ({
       series: [
         {
           name: "Signal",
-          data: initECGsData,
+          data: initCardiacData,
           color: "#3562BD",
           turboThreshold: 0,
           states: {

--- a/beat-editor/src/components/ChartOptions.js
+++ b/beat-editor/src/components/ChartOptions.js
@@ -75,7 +75,7 @@ const createChartOptions = ({
       },
       series: [
         {
-          name: "ECG",
+          name: "Signal",
           data: initECGsData,
           color: "#3562BD",
           turboThreshold: 0,
@@ -131,6 +131,9 @@ const createChartOptions = ({
             hover: {
               enabled: false,
             },
+            inactive: {
+              enabled: false,
+            }
           },
           point: {
             events: {

--- a/beat-editor/src/hooks/useChartZoom.js
+++ b/beat-editor/src/hooks/useChartZoom.js
@@ -17,7 +17,7 @@ const useChartZoom = (chartRef, chartOptions) => {
         const minY = yAxis.min;
         const maxY = yAxis.max;
 
-        // Get the data's full range across all series (ECG, Beats, Artifacts)
+        // Get the data's full range across all series (Signal, Beats, Artifacts)
         let allXValues = [];
         let allYValues = [];
 


### PR DESCRIPTION
### Link to Issue
[[BE-4] Inconsistent beat rendering and signal label in legend #15
](https://github.com/cbslneu/heartview/issues/15)

### Summary
Beat editor initially grabbed y-axis data from the `Filtered` key of each objects. Concerns were raised for future uploads not having this column readily available for our backend to parse and fetch. To mitigate this issue, the beat editor now looks for both `Filtered` and now, a `Signal` key in the objects. 

The following screenshot provided, was testing the beat editor loading with a file with a `Signal` column:

![Screenshot 2025-07-03 230430](https://github.com/user-attachments/assets/b019b06a-3a25-40f7-83e2-0261e71b1e86)

Some other minor edits to the UI for to prepare for future upgrades to the editor. (UI update can be seen in the photo above as well). Along with the UI update, also fixed a bug which was blending the `Artifact`  with the `Beat` points.
