### PR TITLE
[DOCS-1] Add Zoom + Panning section and their keyboard shortcuts

### DIFF
--- a/docs/beat-editor-getting-started.rst
+++ b/docs/beat-editor-getting-started.rst
@@ -34,7 +34,7 @@ for the Beat Editor:
     $ cd beat-editor
     $ npm install
 
-Next we needs to install the backend server dependencies.
+Next we need to install the backend server dependencies.
 From the ``beat-editor`` subdirectory, navigate to the ``server``
 and run the following command to install all required modules:
 

--- a/docs/beat-editor-getting-started.rst
+++ b/docs/beat-editor-getting-started.rst
@@ -5,7 +5,7 @@ Getting Started
 Overview
 ========
 HeartView Beat Editor is a user-friendly tool providing out-of-the-box
-functionalizasty for visualizing and editing electrocardiograph and
+functionality for visualizing and editing electrocardiograph and
 photoplethysmograph data.
 
 Manual Installation
@@ -34,6 +34,15 @@ for the Beat Editor:
     $ cd beat-editor
     $ npm install
 
+Next we needs to install the backend server dependencies.
+From the ``beat-editor`` subdirectory, navigate to the ``server``
+and run the following command to install all required modules:
+
+.. code-block:: bash
+
+    $ cd server
+    $ npm install
+
 
 Launching the Beat Editor
 =========================
@@ -55,8 +64,8 @@ If the terminal displays this message, then the server is running successfully:
 
 .. code-block:: bash
   
-    server@1.0.0 start
-    node app.js
+    >server@1.0.0 start
+    >node app.js
 
     Server is running on port 3001
 

--- a/docs/beat-editor-quick-guide.rst
+++ b/docs/beat-editor-quick-guide.rst
@@ -71,7 +71,7 @@ save the current state of the chart to the server.
 
 Zoom
 ====
-To zoom in and out of the chart, use the mouse wheel or click and drag to adjust the view.
+To zoom in and out of the chart, use the ``Mouse Wheel`` or ``Drag-Select``.
 
 .. image:: _static/beat-editor-gifs/Zoom.gif
     :width: 600
@@ -79,7 +79,7 @@ To zoom in and out of the chart, use the mouse wheel or click and drag to adjust
 
 Panning
 =======
-To pan over the chart, hold down the Shift key and click and drag with the mouse.
+To pan over the chart, hold down the ``Shift Key`` and then click and drag with the mouse.
 
 .. image:: _static/beat-editor-gifs/Drag.gif
     :width: 600
@@ -93,5 +93,5 @@ The Beat Editor supports several keyboard shortcuts to enhance workflow:
 - **D** - Delete the selected beat.
 - **U** - Mark the selected beat as unusable.
 - **CTRL + Z** OR **⌘ + Z** (For Mac Users) - Undo the last action.
-- **SHIFT + Left Mouse Click** - To pan over the chart.
-- **Mouse Wheel** OR **Click and Drag** - To zoom in and out of the chart.
+- **SHIFT + Left Mouse Click** - Pan over the chart.
+- **Mouse Wheel** OR **Drag-Select** - Zoom in and out of the chart.

--- a/docs/beat-editor-quick-guide.rst
+++ b/docs/beat-editor-quick-guide.rst
@@ -69,6 +69,21 @@ save the current state of the chart to the server.
     :width: 600
     :align: center
 
+Zoom
+====
+To zoom in and out of the chart, use the mouse wheel or click and drag to adjust the view.
+
+.. image:: _static/beat-editor-gifs/Zoom.gif
+    :width: 600
+    :align: center
+
+Panning
+=======
+To pan over the chart, hold down the Shift key and click and drag with the mouse.
+
+.. image:: _static/beat-editor-gifs/Drag.gif
+    :width: 600
+    :align: center
 
 Keyboard Shortcuts
 ==================
@@ -78,3 +93,5 @@ The Beat Editor supports several keyboard shortcuts to enhance workflow:
 - **D** - Delete the selected beat.
 - **U** - Mark the selected beat as unusable.
 - **CTRL + Z** OR **⌘ + Z** (For Mac Users) - Undo the last action.
+- **SHIFT + Left Mouse Click** - To pan over the chart.
+- **Mouse Wheel** OR **Click and Drag** - To zoom in and out of the chart.


### PR DESCRIPTION
### Link to Issue
[[DOCS-1] Incomplete Installation and Quick Guide instructions #24](https://github.com/cbslneu/heartview/issues/24)

### Summary
Missing sections for **Zoom** and **Panning** with their respective keyboard shortcuts in the `Quick Guide` section of the docs.

### Screenshots

![Screenshot 2025-07-06 135835](https://github.com/user-attachments/assets/debc67dc-8a97-405d-9745-79100767c570)


![Screenshot 2025-07-06 140025](https://github.com/user-attachments/assets/5bc90268-6a95-42c8-b5b3-42546713c7d4)
