### PR TITLE
BE-12: Developed alternative solution for panning and mark unusable

### DIFF
--- a/beat-editor/.gitignore
+++ b/beat-editor/.gitignore
@@ -18,6 +18,8 @@ node_modules
 .env.test.local
 .env.production.local
 
+.vite/
+
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/beat-editor/frontend/hooks/useMarkingUnusableMode.ts
+++ b/beat-editor/frontend/hooks/useMarkingUnusableMode.ts
@@ -46,12 +46,12 @@ const useMarkingUnusableMode = (
       }
 
       const handleMouseDown = (event: MouseEvent) => {
-        if (isMarkingUnusableMode) {
+        if (isMarkingUnusableMode && !event.shiftKey) {
           const target = event.target as HTMLElement;
-          if (target && target.textContent?.includes('Reset zoom')) {
+          if (target && target.textContent?.includes("Reset zoom")) {
             return;
           }
-          
+
           event.preventDefault();
 
           const chartPosition = getChartPosition(event);
@@ -64,8 +64,12 @@ const useMarkingUnusableMode = (
         }
       };
 
+      const preventContextMenu = (event: Event) => event.preventDefault();
+
+      document.addEventListener("contextmenu", preventContextMenu);
+
       const handleMouseMove = (event: MouseEvent) => {
-        if (isMarkingUnusableMode && isDraggingRef.current) {
+        if (isMarkingUnusableMode && isDraggingRef.current && !event.shiftKey) {
           const chartPosition = getChartPosition(event);
           let dragEnd = chart.xAxis[0].toValue(chartPosition.x);
 
@@ -148,8 +152,9 @@ const useMarkingUnusableMode = (
           chart.xAxis[0].removePlotBand("draggingPlotBand");
           dragPlotBandRef.current = null;
         }
-
+        
         // Cleanup event listeners
+        document.removeEventListener("contextmenu", preventContextMenu);
         chart.container.removeEventListener("mousedown", handleMouseDown);
         chart.container.removeEventListener("mousemove", handleMouseMove);
         window.removeEventListener("mouseup", handleMouseUp);

--- a/beat-editor/frontend/utils/CreateChartOptions.ts
+++ b/beat-editor/frontend/utils/CreateChartOptions.ts
@@ -27,13 +27,13 @@ const createChartOptions = ({
           type: isMarkingUnusableMode ? undefined : "x",
         },
         panning: {
-          enabled: !isMarkingUnusableMode, // Enable panning
+          enabled: true, // Disable panning in Mark Unusable mode 
         },
         panKey: "shift",
         events: {
           click: function (event) {
             if (
-              (isAddMode || isDeleteMode || isMarkingUnusableMode) &&
+              (isAddMode || isDeleteMode) &&
               !event.shiftKey
             ) {
               const chartClickEvent: ChartClickEvent = {


### PR DESCRIPTION
### Link to Issue
[[BE-12] Pan with SHIFT does not work in 'Mark Unusable' mode #38](https://github.com/cbslneu/heartview/issues/38)

### Summary
`useMarkingUnusableMode`'s functionality was coinciding with `highcharts`'s inherent zoom drag function, which was creating conflict between the custom hook and the chart's function. Used a different approach, suggested by @nmy2103 to use the right mouse button instead. Was able to get it functioning with the right mouse button (middle mouse button works as well). Will have to make note that the left mouse button may coincide with other chart functionalities.