### PR TITLE
[DB-9] Fix ValueError: zero-dimensional arrays cannot be concatenated in the export function

### DIFF
--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -2517,10 +2517,12 @@ def get_callbacks(app):
                             ends = np.ceil(
                                 (mapped_unusable_ix + 1) * ratio).astype(int)
                             ends = np.maximum(ends, starts + 1)
-                            for s, e in zip(starts, ends):
-                                parts = np.arange(s, min(e, len(data)), dtype = int)
-                            if parts:
-                                full = np.unique(np.concatenate(parts))
+                            parts = np.array([], dtype = int)
+                            for start, end in zip(starts, ends):
+                                part = np.arange(start, min(end, len(data)), dtype = int)
+                                parts = np.concatenate([parts, part])
+                            if len(parts) > 0:
+                                full = np.unique(parts)
                                 data.loc[full, 'Unusable'] = 1
 
                     # Reposition columns for clarity


### PR DESCRIPTION
## Link to issues
- Closes https://github.com/cbslneu/physioview/issues/58

## Summary
This PR
- Fixes `ValueError: zero-dimensional arrays cannot be concatenated` error during export by concatenating `part` in every loop instead of re-initializing it
- Changed variables `s` and `e` to `start` and `end` to avoid overwriting the argument `s`
