### PR TITLE
DB-10: Fix index error in PPG processing

### DIFF
--- a/physioview/pipeline/PPG.py
+++ b/physioview/pipeline/PPG.py
@@ -217,7 +217,7 @@ class BeatDetectors:
         ma = rmean + mn
 
         peaksx = np.where((signal > ma))[0]
-        peaksy = signal[peaksx]
+        peaksy = signal.reset_index(drop=True).iloc[peaksx]
         peakedges = np.concatenate((np.array([0]),
                                     (np.where(np.diff(peaksx) > 1)[0]),
                                     np.array([len(peaksx)])))


### PR DESCRIPTION
### Link to issue
- Closes: #60 

### Summary
This PR fixes an index error in PPG processing by resetting the index of the `signal` array before extracting beat locations.