### PR TITLE
DB-11: Fix segment mismatch in _edit.json for Beat Editor

### DIFF
--- a/physioview/dashboard/utils.py
+++ b/physioview/dashboard/utils.py
@@ -1,5 +1,5 @@
 import zipfile
-from typing import Callable, Literal, Optional, Union
+from typing import Callable, Optional, Union
 from pathlib import Path
 from shutil import rmtree
 from zipfile import ZipFile

--- a/physioview/dashboard/utils.py
+++ b/physioview/dashboard/utils.py
@@ -1,5 +1,5 @@
 import zipfile
-from typing import Callable, Optional, Union
+from typing import Callable, Literal, Optional, Union
 from pathlib import Path
 from shutil import rmtree
 from zipfile import ZipFile
@@ -556,6 +556,8 @@ def _downsample_data(
         # Decimate primary signal
         y_dec = __decimate(df[y_col])
         ds = pd.DataFrame({x_col: df[x_col].iloc[ds_idx].to_numpy(), y_col: y_dec})
+        if 'Segment' in df.columns:
+            ds['Segment'] = df['Segment'].iloc[ds_idx].to_numpy()
 
         # Rescale detected, artifactual, and corrected beat indices
         down_beats = np.rint(


### PR DESCRIPTION
### Link to Issue
Resolves #67

### Summary
This PR fixes a bug where the Beat Editor's `_edit.json` was not reflecting the newly segmented data after the user changed the segment parameter and re-ran the preprocessing pipeline.

The `Segment` column was not being carried over when building the downsampled DataFrame in `dashboard.utils._downsample_data()`, which caused `physioview.write_beat_editor_file()` to fall back to segmenting the data using the default 60-second window.