### PR TITLE
[DB-8] Disable filter when filtering toggled off and add more flexible parameter customization

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -719,7 +719,7 @@ button:hover {
 #filter-config-btn {
     width: auto;
     height: 26px;
-    background: #ee8a78;
+    background-color: #47555e;
     font-size: 11pt;
     display: flex;
     align-items: center;
@@ -727,7 +727,7 @@ button:hover {
     padding: 0px 4px 0px 5px;
 }
 #filter-config-btn:hover {
-    background: #ce6e5d !important;
+    background-color: #313d44;
 }
 #run-save-buttons {
     margin-top: -5px;

--- a/assets/style.css
+++ b/assets/style.css
@@ -438,6 +438,11 @@ h6 {
     display: block;
     padding-bottom: 5px;
 }
+.filter-config-error {
+    color: #d32f2f;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
 #filter-lowcut, #filter-highcut, #filter-order, #filter-rp, #filter-rs, #filter-window-len, #filter-length {
     width: 65px;
 }
@@ -464,6 +469,13 @@ h6 {
     margin-top: 5px;
     margin-bottom: 5px;
     align-items: left;
+}
+#reset-to-default-btn {
+    font-size: 10pt;
+    color: #ee8a78;
+    text-decoration: underline;
+    cursor: pointer;
+    margin-left: 15px;
 }
 /* --- file uploaders ------------------------------------------------------*/
 #config-uploader { /* configuration file uploader */
@@ -946,7 +958,7 @@ th:first-child {  /* style only first table header */
 #ok-export:hover, #config-btn:hover, #apply-filter-btn:hover {
     background-color: #313d44;
 }
-#close-export, #close-config1, #reset-config-btn {
+#close-export, #close-config1, #cancel-config-btn {
     background-color: #bbbbbb;
     padding: 8px;
     font-weight: bold;
@@ -964,7 +976,7 @@ th:first-child {  /* style only first table header */
     letter-spacing: 2px;
     position: relative;
 }
-#close-export:hover, #close-config1:hover, #reset-config-btn:hover {
+#close-export:hover, #close-config1:hover, #cancel-config-btn:hover {
     background-color: #969696 !important;
 }
 .fa-download {

--- a/assets/style.css
+++ b/assets/style.css
@@ -439,7 +439,7 @@ h6 {
     padding-bottom: 5px;
 }
 #filter-lowcut, #filter-highcut, #filter-order, #filter-rp, #filter-rs, #filter-window-len {
-    width: 50px;
+    width: 55px;
 }
 #lower-cutoff-div, #upper-cutoff-div, #filter-order-div, #filter-rp-div, #filter-rs-div, #filter-window-len-div {
     display: inline-flex;

--- a/assets/style.css
+++ b/assets/style.css
@@ -438,10 +438,10 @@ h6 {
     display: block;
     padding-bottom: 5px;
 }
-#filter-lowcut, #filter-highcut, #filter-order, #filter-rp, #filter-rs {
+#filter-lowcut, #filter-highcut, #filter-order, #filter-rp, #filter-rs, #filter-window-len {
     width: 50px;
 }
-#lower-cutoff-div, #upper-cutoff-div, #filter-order-div, #filter-rp-div, #filter-rs-div {
+#lower-cutoff-div, #upper-cutoff-div, #filter-order-div, #filter-rp-div, #filter-rs-div, #filter-window-len-div {
     display: inline-flex;
     align-items: center;
     gap: 0.5em;

--- a/assets/style.css
+++ b/assets/style.css
@@ -417,7 +417,7 @@ h6 {
     font-size: 9.5pt;
 }
 /* --- help icons ----------------------------------------------------------*/
-#filter-help {
+#filter-help, #selected-filter-help, #filter-parameters-help {
     margin-left: 5px;
     font-size: 13pt;
 }
@@ -438,54 +438,28 @@ h6 {
     display: block;
     padding-bottom: 5px;
 }
-#filter-config-link {
-    color: #ee8a78 !important;
-    font-weight: 400 !important;
-    font-size: 9pt !important;
-    margin-left: 10px;
-    letter-spacing: 0.7pt;
-}
-#filter-config-link:hover {
-    text-decoration: underline;
-}
-#filter-config-collapse {
-    width: 100%;
-}
-.filter-config-hidden {
-    max-height: 0;
-    opacity: 0;
-    overflow: hidden;
-    transform-origin: top;
-    transition: max-height 0.35s ease-out, opacity 0.25s ease-out;
-}
-.filter-config-visible {
-    max-height: 150px;
-    opacity: 1;
-    overflow: hidden;
-    transform-origin: top;
-    transition: max-height 0.35s ease-in, opacity 0.25s ease-in 0.1s;
-    padding-top: 8px;
-}
-#filter-lowcut, #filter-highcut {
+#filter-lowcut, #filter-highcut, #filter-order, #filter-rp, #filter-rs {
     width: 50px;
 }
-#filter-config-collapse .card {
-    border-radius: 5px;
-    border: 1px dashed #ee8a78;
-    background-color: #fae0da;
-}
-#filter-config-collapse .card-body {
-    padding: 10px;
-    display: flex;
-    gap: 0.5em;
-    align-items: center;
-    justify-content: space-between;
-    font-size: 9.5pt;
-}
-#lower-cutoff-div, #upper-cutoff-div {
+#lower-cutoff-div, #upper-cutoff-div, #filter-order-div, #filter-rp-div, #filter-rs-div {
     display: inline-flex;
     align-items: center;
     gap: 0.5em;
+}
+#filter-parameters-container, #selected-filter-container {
+    margin-bottom: 20px;
+    margin-top: 10px;
+}
+#selected-filter-label, #filter-parameters-label {
+    font-weight: 600;
+    margin-top: 20px;
+    width: 100%;
+}
+.filter-config-item {
+    width: 100%;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    align-items: left;
 }
 /* --- file uploaders ------------------------------------------------------*/
 #config-uploader { /* configuration file uploader */
@@ -726,6 +700,19 @@ button:hover {
 #setup-signal {  /* dropdown 2*/
     flex: 1 0 8%;
 }
+#filter-config-btn {
+    width: auto;
+    height: 26px;
+    background: #ee8a78;
+    font-size: 11pt;
+    display: flex;
+    align-items: center;
+    color: #ffffff;
+    padding: 0px 4px 0px 5px;
+}
+#filter-config-btn:hover {
+    background: #ce6e5d !important;
+}
 #run-save-buttons {
     margin-top: -5px;
 }
@@ -946,16 +933,16 @@ th:first-child {  /* style only first table header */
 #export-modal .modal-body {
     padding-bottom: 0.5em;
 }
-#ok-export, #config-btn {
+#ok-export, #config-btn, #apply-filter-btn {
     background-color: #47555e;
     position: relative;
     float: left;
     max-width: 225px;
 }
-#ok-export:hover, #config-btn:hover {
+#ok-export:hover, #config-btn:hover, #apply-filter-btn:hover {
     background-color: #313d44;
 }
-#close-export, #close-config1 {
+#close-export, #close-config1, #reset-config-btn {
     background-color: #bbbbbb;
     padding: 8px;
     font-weight: bold;
@@ -965,7 +952,7 @@ th:first-child {  /* style only first table header */
     float: right;
     max-width: 225px;
 }
-#close-export2, #close-config2 {
+#close-export2, #close-config2, #apply-filter-btn {
     background-color: #47555e;
     padding: 8px;
     font-weight: bold;
@@ -973,7 +960,7 @@ th:first-child {  /* style only first table header */
     letter-spacing: 2px;
     position: relative;
 }
-#close-export:hover, #close-config1:hover {
+#close-export:hover, #close-config1:hover, #reset-config-btn:hover {
     background-color: #969696 !important;
 }
 .fa-download {

--- a/assets/style.css
+++ b/assets/style.css
@@ -438,10 +438,14 @@ h6 {
     display: block;
     padding-bottom: 5px;
 }
-#filter-lowcut, #filter-highcut, #filter-order, #filter-rp, #filter-rs, #filter-window-len {
-    width: 55px;
+#filter-lowcut, #filter-highcut, #filter-order, #filter-rp, #filter-rs, #filter-window-len, #filter-length {
+    width: 65px;
 }
-#lower-cutoff-div, #upper-cutoff-div, #filter-order-div, #filter-rp-div, #filter-rs-div, #filter-window-len-div {
+#filter-window-type {
+    width: 150px;
+}
+#lower-cutoff-div, #upper-cutoff-div, #filter-order-div, #filter-rp-div, #filter-rs-div, 
+#filter-window-len-div, #filter-length-div, #filter-window-type-div {
     display: inline-flex;
     align-items: center;
     gap: 0.5em;

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -773,7 +773,6 @@ def get_callbacks(app):
             Output('dtype-validator', 'is_open', allow_duplicate=True),
             Output('mapping-validator', 'is_open'),
             Output('pipeline-error-modal', 'is_open'),
-            Output('pipeline-error-message', 'children'),
             Output('duplicate-temp-error-modal', 'is_open'),
             Output('memory-db', 'data'),
         ],
@@ -849,11 +848,11 @@ def get_callbacks(app):
             if file_type not in ('Actiwave', 'E4'):
                 if dtype is None:
                     dtype_error = True
-                    return dtype_error, map_error, pipeline_error, '', \
+                    return dtype_error, map_error, pipeline_error, \
                         temp_input_error, None
                 elif d2 is None:
                     map_error = True
-                    return dtype_error, map_error, pipeline_error, '', \
+                    return dtype_error, map_error, pipeline_error, \
                         temp_input_error, None
 
             filepath = load_data['filename']
@@ -942,19 +941,14 @@ def get_callbacks(app):
                             if isinstance(preprocessed, tuple) and \
                                     all(x is None for x in preprocessed):
                                 pipeline_error = True
-                                error_msg = ('PipelineError: No beats detected. '
-                                             'Please try a different beat '
-                                             'detector.')
                                 return dtype_error, map_error, pipeline_error, \
-                                    error_msg, temp_input_error, None
+                                    temp_input_error, None
 
                         except Exception as e:
                             pipeline_error = True
-                            error_type = type(e).__name__
-                            error_msg = f'{error_type}: {e}'
                             print(traceback.format_exc())
                             return dtype_error, map_error, pipeline_error, \
-                                error_msg, temp_input_error, None
+                                temp_input_error, None
                         metrics = preprocessed[2]
 
                         # Write IBI data to 'temp' folder
@@ -981,9 +975,9 @@ def get_callbacks(app):
                         except Exception as e:
                             pipeline_error = True
                             error_type = type(e).__name__
-                            error_msg = f'{error_type}: {e}'
+                            print(traceback.format_exc())
                             return dtype_error, map_error, pipeline_error, \
-                                error_msg, temp_input_error, None
+                                temp_input_error, None
                         metrics = preprocessed[1]
 
                         # Get downsampled data for rendering
@@ -1086,7 +1080,7 @@ def get_callbacks(app):
                     # Check if duplicate temperature inputs
                     if temp_data is not None and temp_var is not None:
                         temp_input_error = True
-                        return dtype_error, map_error, pipeline_error, '', \
+                        return dtype_error, map_error, pipeline_error, \
                             temp_input_error, None
 
                     # If timestamps are given
@@ -1150,19 +1144,15 @@ def get_callbacks(app):
                         if isinstance(preprocessed, tuple) and \
                                 all(x is None for x in preprocessed):
                             pipeline_error = True
-                            error_msg = ('PipelineError: No beats detected. '
-                                         'Please try a different beat '
-                                         'detector.')
+                            print(traceback.format_exc())
                             return dtype_error, map_error, pipeline_error, \
-                                error_msg, temp_input_error, None
+                                temp_input_error, None
 
                     except Exception as e:
                         pipeline_error = True
-                        error_type = type(e).__name__
-                        error_msg = f'{error_type}: {e}'
                         print(traceback.format_exc())
                         return dtype_error, map_error, pipeline_error, \
-                            error_msg, temp_input_error, None
+                            temp_input_error, None
                     metrics = preprocessed[2]
 
                     # Write IBI data to 'temp' folder
@@ -1203,7 +1193,7 @@ def get_callbacks(app):
                         error_msg = f'{error_type}: {e}'
                         print(traceback.format_exc())
                         return dtype_error, map_error, pipeline_error, \
-                            error_msg, temp_input_error, None
+                            temp_input_error, None
                     metrics = preprocessed[1]
 
                 # Write preprocessed data and metrics to 'temp' folder
@@ -1257,7 +1247,7 @@ def get_callbacks(app):
             set_progress((100, '100%'))
             sleep(1)
 
-            return [dtype_error, map_error, pipeline_error, '',
+            return [dtype_error, map_error, pipeline_error,
                     temp_input_error, memory]
 
     # == Recompute SQA metrics for re-rendering ==============================

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -326,6 +326,8 @@ def get_callbacks(app):
          Output('filter-rp', 'value', allow_duplicate = True),
          Output('filter-rs-div', 'hidden'),
          Output('filter-rs', 'value', allow_duplicate = True),
+         Output('filter-window-len-div', 'hidden'),
+         Output('filter-window-len', 'value', allow_duplicate = True),
          Output('selected-filter', 'children')],
         [Input('memory-load', 'data'),
          Input('data-types', 'value'),
@@ -342,21 +344,21 @@ def get_callbacks(app):
             dtype = 'ECG'
 
         if dtype in ['ECG', 'PPG', 'EDA']:
-            lowcut, highcut, order, rp, rs, filt_type = utils._default_filter_params(dtype, beat_detector)
+            lowcut, highcut, order, rp, rs, window_len, filt_type = utils._default_filter_params(dtype, beat_detector)
             selected_filter_children = filt_type
         elif e4_dtype in ['PPG', 'EDA']:
-            lowcut, highcut, order, rp, rs, filt_type = utils._default_filter_params(e4_dtype, beat_detector)
+            lowcut, highcut, order, rp, rs, window_len, filt_type = utils._default_filter_params(e4_dtype, beat_detector)
             selected_filter_children = filt_type
         else:
-            lowcut, highcut, order, rp, rs, filt_type = None, None, None, None, None, None
-            selected_filter_children = 'Please select the signal type to customize the filter settings.'
+            lowcut, highcut, order, rp, rs, window_len, filt_type = None, None, None, None, None, None, None
+            selected_filter_children = 'No filter selected.'
 
         disable_lowcut = True if lowcut is None else False
         hide_order = True if order is None else False
         hide_rp = True if rp is None else False
         hide_rs = True if rs is None else False
-
-        return [disable_lowcut, lowcut, highcut, hide_order, order, hide_rp, rp, hide_rs, rs, selected_filter_children]
+        hide_window_len = True if window_len is None else False
+        return [disable_lowcut, lowcut, highcut, hide_order, order, hide_rp, rp, hide_rs, rs, hide_window_len, window_len, selected_filter_children]
 
     # === Close filter customization modal =====================================
     @app.callback(
@@ -793,6 +795,7 @@ def get_callbacks(app):
             State('filter-order', 'value'),
             State('filter-rp', 'value'),
             State('filter-rs', 'value'),
+            State('filter-window-len', 'value'),
             State('scr-detectors', 'value'),
             State('scr-amp-thresh', 'value'),
             State('eda-valid-min', 'value'),
@@ -817,7 +820,7 @@ def get_callbacks(app):
                      d2, d3, d4, d5, temp_data, temp_var, beat_detector,
                      seg_size, artifact_method, artifact_tol, filt_on,
                      filter_lowcut, filter_highcut, filter_order, filter_rp, filter_rs, 
-                     scr_detector, scr_amp, eda_min, eda_max):
+                     filter_window_len, scr_detector, scr_amp, eda_min, eda_max):
         """Read Actiwave Cardio, Empatica E4, or CSV-formatted data, save
         the data to the local memory, and load the progress spinner."""
 
@@ -926,6 +929,7 @@ def get_callbacks(app):
                                 artifact_method, artifact_tol, filt_on,
                                 filter_lowcut, filter_highcut,
                                 filter_order, filter_rp, filter_rs,
+                                filter_window_len,
                                 acc_data = acc, downsample = ds)
 
                             # Throw beat detection error
@@ -1132,6 +1136,8 @@ def get_callbacks(app):
                             data, dtype, fs, seg_size, beat_detector,
                             artifact_method, artifact_tol, filt_on,
                             filter_lowcut, filter_highcut,
+                            filter_order, filter_rp, filter_rs,
+                            filter_window_len,
                             acc_data = acc, downsample = ds)
 
                         # Throw beat detection error

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -306,27 +306,40 @@ def get_callbacks(app):
         # Otherwise, keep the link and settings hidden
         return True, 'filter-config-hidden'
 
-    # === Set filter cutoff values ============================================
+    # === Set filter parameters ============================================
     @app.callback(
         [Output('filter-lowcut', 'disabled'),
          Output('filter-lowcut', 'value', allow_duplicate = True),
-         Output('filter-highcut', 'value', allow_duplicate = True)],
+         Output('filter-highcut', 'value', allow_duplicate = True),
+         Output('filter-order-div', 'hidden'),
+         Output('filter-order', 'value', allow_duplicate = True),
+         Output('filter-rp-div', 'hidden'),
+         Output('filter-rp', 'value', allow_duplicate = True),
+         Output('filter-rs-div', 'hidden'),
+         Output('filter-rs', 'value', allow_duplicate = True)],
         [Input('data-types', 'value'),
-         Input('e4-data-types', 'value')],
+         Input('e4-data-types', 'value'),
+         Input('beat-detectors', 'value')],
         prevent_initial_call = True
     )
-    def disable_lowcut_input(dtype, e4_dtype):
+    def disable_lowcut_input(dtype, e4_dtype, beat_detector):
         """Disable the filter lowcut input and customize the highcut input
         and value depending on the inputted data type."""
-        ecg_filter_params = [False, 5, 15]
-        ppg_filter_params = [False, 0.5, 10]
-        eda_filter_params = [True, None, 0.35]
+        ppg_filter_params = [False, 0.5, 10, True, None, True, None, True, None]
+        eda_filter_params = [True, None, 0.35, True, None, True, None, True, None]
         if dtype == 'EDA' or e4_dtype == 'EDA':
             return eda_filter_params
         elif dtype == 'PPG' or e4_dtype == 'PPG':
             return ppg_filter_params
         else:
-            return ecg_filter_params
+            if beat_detector == 'engzee':
+                return [False, 1, 15, True, None, True, None, True, None]
+            elif beat_detector == 'manikandan':
+                return [False, 6, 18, False, 4, False, 1, True, None]
+            elif beat_detector == 'nabian':
+                return [False, 0.5, 50, False, 2, False, 0.5, False, 40]
+            elif beat_detector == 'pantompkins':
+                return [False, 0.5, 15, False, 2, True, None, True, None]
 
     # === Read temperature data file if provided ==============================
     @app.callback(
@@ -751,6 +764,9 @@ def get_callbacks(app):
             State('toggle-filter', 'on'),
             State('filter-lowcut', 'value'),
             State('filter-highcut', 'value'),
+            State('filter-order', 'value'),
+            State('filter-rp', 'value'),
+            State('filter-rs', 'value'),
             State('scr-detectors', 'value'),
             State('scr-amp-thresh', 'value'),
             State('eda-valid-min', 'value'),
@@ -774,8 +790,8 @@ def get_callbacks(app):
     def run_pipeline(set_progress, n, load_data, e4_dtype, dtype, fs, rs, d1,
                      d2, d3, d4, d5, temp_data, temp_var, beat_detector,
                      seg_size, artifact_method, artifact_tol, filt_on,
-                     filter_lowcut, filter_highcut, scr_detector, scr_amp,
-                     eda_min, eda_max):
+                     filter_lowcut, filter_highcut, filter_order, filter_rp, filter_rs, 
+                     scr_detector, scr_amp, eda_min, eda_max):
         """Read Actiwave Cardio, Empatica E4, or CSV-formatted data, save
         the data to the local memory, and load the progress spinner."""
 
@@ -883,6 +899,7 @@ def get_callbacks(app):
                                 data, dtype, fs, seg_size, beat_detector,
                                 artifact_method, artifact_tol, filt_on,
                                 filter_lowcut, filter_highcut,
+                                filter_order, filter_rp, filter_rs,
                                 acc_data = acc, downsample = ds)
 
                             # Throw beat detection error

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -438,7 +438,7 @@ def get_callbacks(app):
 
         # Default toggler states
         temp_on = False
-        filter_on = False
+        filter_on = True
 
         # Default parameter values
         base_headers = ['<Var>', '<Var>']

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -337,10 +337,11 @@ def get_callbacks(app):
          Input('data-types', 'value'),
          Input('e4-data-types', 'value'),
          Input('beat-detectors', 'value'),
-         Input('reset-config-btn', 'n_clicks')],
+         Input('cancel-config-btn', 'n_clicks'),
+         Input('reset-to-default-btn', 'n_clicks')],
         prevent_initial_call = True
     )
-    def set_default_filter_params(data, dtype, e4_dtype, beat_detector, n_cancel):
+    def set_default_filter_params(data, dtype, e4_dtype, beat_detector, n_cancel, n_reset):
         """Disable the filter lowcut input and customize the highcut input
         and value depending on the inputted data type."""
         
@@ -368,12 +369,61 @@ def get_callbacks(app):
 
     # === Close filter customization modal =====================================
     @app.callback(
-        Output('filter-customization-modal', 'is_open', allow_duplicate = True),
-        Input('apply-filter-btn', 'n_clicks'),
+        [Output('filter-customization-modal', 'is_open', allow_duplicate = True),
+         Output('empty-param-error-div', 'hidden'),
+         Output('lowcut-highcut-error-div', 'hidden')],
+        [Input('apply-filter-btn', 'n_clicks'),
+         Input('cancel-config-btn', 'n_clicks'),
+         Input('reset-to-default-btn', 'n_clicks')],
+        [State('lower-cutoff-div', 'hidden'),
+         State('filter-lowcut', 'value'),
+         State('upper-cutoff-div', 'hidden'),
+         State('filter-highcut', 'value'),
+         State('filter-order-div', 'hidden'),
+         State('filter-order', 'value'),
+         State('filter-rp-div', 'hidden'),
+         State('filter-rp', 'value'),
+         State('filter-rs-div', 'hidden'),
+         State('filter-rs', 'value'),
+         State('filter-window-len-div', 'hidden'),
+         State('filter-window-len', 'value'),
+         State('filter-length-div', 'hidden'),
+         State('filter-length', 'value'),
+         State('filter-window-type-div', 'hidden'),
+         State('filter-window-type', 'value')],
         prevent_initial_call = True
     )
-    def close_filter_customization_modal(n_apply):
-        return False
+    def close_filter_customization_modal(n_apply, n_cancel, n_reset, hide_lowcut, lowcut, hide_highcut, highcut, \
+        hide_order, order, hide_rp, rp, hide_rs, rs, hide_window_len, window_len, hide_filter_length, \
+            filter_length, hide_window_type, window_type):
+        """Close the filter customization modal and validate the filter parameters."""
+
+        trig = ctx.triggered_id
+
+        if trig == 'reset-to-default-btn':
+            return True, True, True
+
+        if trig == 'cancel-config-btn':
+            return False, True, True
+
+        lowcut_empty = True if not hide_lowcut and lowcut is None else False
+        highcut_empty = True if not hide_highcut and highcut is None else False
+        order_empty = True if not hide_order and order is None else False
+        rp_empty = True if not hide_rp and rp is None else False
+        rs_empty = True if not hide_rs and rs is None else False
+        window_len_empty = True if not hide_window_len and window_len is None else False
+        filter_length_empty = True if not hide_filter_length and filter_length is None else False
+        window_type_empty = True if not hide_window_type and window_type is None else False
+
+        hide_empty_param_error = not any([lowcut_empty, highcut_empty, order_empty, rp_empty, rs_empty, window_len_empty, filter_length_empty, window_type_empty])
+        if hide_empty_param_error:
+            hide_lowcut_highcut_error = False if not hide_lowcut and not hide_highcut and lowcut >= highcut else True
+        else:
+            hide_lowcut_highcut_error = True
+
+        open_modal = False if hide_empty_param_error and hide_lowcut_highcut_error else True
+
+        return [open_modal, hide_empty_param_error, hide_lowcut_highcut_error]
 
     # === Read temperature data file if provided ==============================
     @app.callback(

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -190,7 +190,8 @@ def get_callbacks(app):
          Output('resampling-rate', 'disabled'),
          Output('load-temperature', 'hidden'),
          Output('temp-upload-section', 'hidden'),
-         Output('cardio-preprocessing', 'hidden'),
+         Output('beat-detector-settings', 'hidden'),
+         Output('artifact-settings', 'hidden'),
          Output('eda-preprocessing', 'hidden', allow_duplicate = True),
          Output('scr-amplitude-threshold', 'hidden'),
          Output('beat-detectors', 'options'),
@@ -227,7 +228,8 @@ def get_callbacks(app):
         if dtype == 'EDA' or e4_dtype == 'EDA':
             resample_hidden = False
             load_temp_hidden = False
-            cardio_preprocess_hidden = True
+            beat_detector_settings_hidden = True
+            artifact_settings_hidden = True
             eda_preprocess_hidden = False
             seg_size = 180
             if toggle_rs_on is True:
@@ -246,7 +248,8 @@ def get_callbacks(app):
         if dtype in ('PPG', 'ECG')  or e4_dtype == 'PPG' or data_source == 'Actiwave':
             fs = 500
             eda_preprocess_hidden = True
-            cardio_preprocess_hidden = False
+            beat_detector_settings_hidden = False
+            artifact_settings_hidden = False
             if dtype == 'PPG' or e4_dtype == 'PPG':
                 beat_detectors = [
                     {'label': 'Elgendi et al. (2013)', 'value': 'erma'},
@@ -263,7 +266,7 @@ def get_callbacks(app):
 
         return [fs, resample_hidden, resample_disabled,
                 load_temp_hidden, temp_upload_hidden,
-                cardio_preprocess_hidden, eda_preprocess_hidden,
+                beat_detector_settings_hidden, artifact_settings_hidden, eda_preprocess_hidden,
                 scr_amp_thresh_hidden, beat_detectors, default_beat_detector,
                 scr_detectors, default_scr_detector, seg_size]
 

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -272,39 +272,48 @@ def get_callbacks(app):
 
     # === Open advanced filter cutoff settings ================================
     @app.callback(
-        [Output('filter-config-link', 'hidden'),
-         Output('filter-config-collapse', 'className')],
+        [Output('filter-config-btn', 'hidden'),
+         Output('filter-customization-modal', 'is_open'),
+         Output('dtype-validator', 'is_open')],
         [Input('toggle-filter', 'on'),
-         Input('filter-config-link', 'n_clicks')],
-        State('filter-config-collapse', 'className'),
+         Input('filter-config-btn', 'n_clicks')],
+        [State('memory-load', 'data'),
+         State('data-types', 'value'),
+         State('e4-data-types', 'value')],
         prevent_initial_call = True
     )
-    def handle_filter_config_link(filter_on, n_clicks, current_class):
+    def handle_filter_config_link(filter_on, n_clicks, data, dtype, e4_dtype):
         """Enable/disable the filter settings link based on the filter
         toggle state and display/hide the settings when the link is clicked."""
         trig = ctx.triggered_id
-        if current_class is None:
-            current_class = 'filter-config-hidden'
 
         # Handle filter toggle
         if trig == 'toggle-filter':
             if filter_on:
                 # Filter enabled; keep settings hidden
-                return False, 'filter-config-hidden'
+                return False, False, False
             else:
                 # Filter disabled; hide link and settings
-                return True, 'filter-config-hidden'
+                return True, False, False
 
         # Handle link click only if the filter oggle is already on
-        if trig == 'filter-config-link':
+        if trig == 'filter-config-btn':
             if filter_on:
-                if current_class == 'filter-config-hidden':
-                    return False, 'filter-config-visible'
+                if data['source'] == 'Actiwave':
+                    return False, True, False
+                elif data['source'] == 'E4':
+                    if e4_dtype is None:
+                        return False, False, True
+                    else:
+                        return False, True, False
                 else:
-                    return False, 'filter-config-hidden'
+                    if dtype is None:
+                        return False, False, True
+                    else:
+                        return False, True, False
 
         # Otherwise, keep the link and settings hidden
-        return True, 'filter-config-hidden'
+        return True, False, False
 
     # === Set filter parameters ============================================
     @app.callback(
@@ -316,30 +325,47 @@ def get_callbacks(app):
          Output('filter-rp-div', 'hidden'),
          Output('filter-rp', 'value', allow_duplicate = True),
          Output('filter-rs-div', 'hidden'),
-         Output('filter-rs', 'value', allow_duplicate = True)],
-        [Input('data-types', 'value'),
+         Output('filter-rs', 'value', allow_duplicate = True),
+         Output('selected-filter', 'children')],
+        [Input('memory-load', 'data'),
+         Input('data-types', 'value'),
          Input('e4-data-types', 'value'),
-         Input('beat-detectors', 'value')],
+         Input('beat-detectors', 'value'),
+         Input('reset-config-btn', 'n_clicks')],
         prevent_initial_call = True
     )
-    def disable_lowcut_input(dtype, e4_dtype, beat_detector):
+    def set_default_filter_params(data, dtype, e4_dtype, beat_detector, n_cancel):
         """Disable the filter lowcut input and customize the highcut input
         and value depending on the inputted data type."""
-        ppg_filter_params = [False, 0.5, 10, True, None, True, None, True, None]
-        eda_filter_params = [True, None, 0.35, True, None, True, None, True, None]
-        if dtype == 'EDA' or e4_dtype == 'EDA':
-            return eda_filter_params
-        elif dtype == 'PPG' or e4_dtype == 'PPG':
-            return ppg_filter_params
+        
+        if data['source'] == 'Actiwave':
+            dtype = 'ECG'
+
+        if dtype in ['ECG', 'PPG', 'EDA']:
+            lowcut, highcut, order, rp, rs, filt_type = utils._default_filter_params(dtype, beat_detector)
+            selected_filter_children = filt_type
+        elif e4_dtype in ['PPG', 'EDA']:
+            lowcut, highcut, order, rp, rs, filt_type = utils._default_filter_params(e4_dtype, beat_detector)
+            selected_filter_children = filt_type
         else:
-            if beat_detector == 'engzee':
-                return [False, 1, 15, True, None, True, None, True, None]
-            elif beat_detector == 'manikandan':
-                return [False, 6, 18, False, 4, False, 1, True, None]
-            elif beat_detector == 'nabian':
-                return [False, 0.5, 50, False, 2, False, 0.5, False, 40]
-            elif beat_detector == 'pantompkins':
-                return [False, 0.5, 15, False, 2, True, None, True, None]
+            lowcut, highcut, order, rp, rs, filt_type = None, None, None, None, None, None
+            selected_filter_children = 'Please select the signal type to customize the filter settings.'
+
+        disable_lowcut = True if lowcut is None else False
+        hide_order = True if order is None else False
+        hide_rp = True if rp is None else False
+        hide_rs = True if rs is None else False
+
+        return [disable_lowcut, lowcut, highcut, hide_order, order, hide_rp, rp, hide_rs, rs, selected_filter_children]
+
+    # === Close filter customization modal =====================================
+    @app.callback(
+        Output('filter-customization-modal', 'is_open', allow_duplicate = True),
+        Input('apply-filter-btn', 'n_clicks'),
+        prevent_initial_call = True
+    )
+    def close_filter_customization_modal(n_apply):
+        return False
 
     # === Read temperature data file if provided ==============================
     @app.callback(
@@ -736,7 +762,7 @@ def get_callbacks(app):
     # ============================= RUN PIPELINE ==============================
     @callback(
         output = [
-            Output('dtype-validator', 'is_open'),
+            Output('dtype-validator', 'is_open', allow_duplicate=True),
             Output('mapping-validator', 'is_open'),
             Output('pipeline-error-modal', 'is_open'),
             Output('pipeline-error-message', 'children'),

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -317,7 +317,7 @@ def get_callbacks(app):
 
     # === Set filter parameters ============================================
     @app.callback(
-        [Output('filter-lowcut', 'disabled'),
+        [Output('lower-cutoff-div', 'hidden'),
          Output('filter-lowcut', 'value', allow_duplicate = True),
          Output('filter-highcut', 'value', allow_duplicate = True),
          Output('filter-order-div', 'hidden'),
@@ -328,6 +328,10 @@ def get_callbacks(app):
          Output('filter-rs', 'value', allow_duplicate = True),
          Output('filter-window-len-div', 'hidden'),
          Output('filter-window-len', 'value', allow_duplicate = True),
+         Output('filter-length-div', 'hidden'),
+         Output('filter-length', 'value', allow_duplicate = True),
+         Output('filter-window-type-div', 'hidden'),
+         Output('filter-window-type', 'value', allow_duplicate = True),
          Output('selected-filter', 'children')],
         [Input('memory-load', 'data'),
          Input('data-types', 'value'),
@@ -344,21 +348,23 @@ def get_callbacks(app):
             dtype = 'ECG'
 
         if dtype in ['ECG', 'PPG', 'EDA']:
-            lowcut, highcut, order, rp, rs, window_len, filt_type = utils._default_filter_params(dtype, beat_detector)
+            lowcut, highcut, order, rp, rs, window_len, filter_length, window_type, filt_type = utils._default_filter_params(dtype, beat_detector)
             selected_filter_children = filt_type
         elif e4_dtype in ['PPG', 'EDA']:
-            lowcut, highcut, order, rp, rs, window_len, filt_type = utils._default_filter_params(e4_dtype, beat_detector)
+            lowcut, highcut, order, rp, rs, window_len, filter_length, window_type, filt_type = utils._default_filter_params(e4_dtype, beat_detector)
             selected_filter_children = filt_type
         else:
-            lowcut, highcut, order, rp, rs, window_len, filt_type = None, None, None, None, None, None, None
+            lowcut, highcut, order, rp, rs, window_len, filter_length, window_type, filt_type = None, None, None, None, None, None, None, None, None
             selected_filter_children = 'No filter selected.'
 
-        disable_lowcut = True if lowcut is None else False
+        hide_lowcut = True if lowcut is None else False
         hide_order = True if order is None else False
         hide_rp = True if rp is None else False
         hide_rs = True if rs is None else False
         hide_window_len = True if window_len is None else False
-        return [disable_lowcut, lowcut, highcut, hide_order, order, hide_rp, rp, hide_rs, rs, hide_window_len, window_len, selected_filter_children]
+        hide_filter_length = True if filter_length is None else False
+        hide_window_type = True if window_type is None else False
+        return [hide_lowcut, lowcut, highcut, hide_order, order, hide_rp, rp, hide_rs, rs, hide_window_len, window_len, hide_filter_length, filter_length, hide_window_type, window_type, selected_filter_children]
 
     # === Close filter customization modal =====================================
     @app.callback(

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -421,14 +421,18 @@ layout = html.Div(id = 'main', children = [
                 html.Span('An error occurred while processing the data. Please check the following:',
                           style = {'fontWeight': '600'}),
                 html.Ul(id = 'pipeline-error-message', children = [
-                    html.Li('The selected data type is correct.'),
-                    html.Li('The configured sampling rate is correct.'),
-                    html.Li('Time/sample and signal columns are mapped correctly.'),
-                    html.Li('The uploaded signal is already filtered or the filter is toggled on. Some beat detectors may not work well with unfiltered signals.'),
-                    html.Li('The custom filter configuration is reasonable.'),
-                    html.Li('The data contains valid signals.'),
-                    html.Li('Try a different beat detector or preprocess the data differently.'),
-                ])
+                    html.Li('The correct data type is selected..'),
+                    html.Li('The sampling rate is correct.'),
+                    html.Li('"Time/sample" and "Signal" are mapped correctly.'),
+                    html.Li(children = [
+                        'Filtering:',
+                        html.Ul(children = [
+                            html.Li('"Filter Signal" is toggled on if the signal is unfiltered.'),
+                            html.Li('The filter configuration is reasonable.'),
+                        ]),
+                    ]),
+                    html.Li('Try a different beat detector.'),
+                ]),
             ])
         ], className = 'validation-error-modal', centered = True),
 

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -192,6 +192,32 @@ layout = html.Div(id = 'main', children = [
                                  options = [], clearable = False)
                 ])
             ]),
+            html.Div(id = 'eda-preprocessing', hidden = True, children = [
+                html.Div(id = 'select-scr-detector', children = [
+                    html.Span('SCR Detector:'),
+                    dcc.Dropdown(id = 'scr-detectors',
+                                 options = [], clearable = False)
+                ]),
+                html.Div(id = 'scr-amplitude-threshold', children = [
+                    html.Span('Minimum Peak Amplitude (µS):'),
+                    dcc.Input(id = 'scr-amp-thresh', value = None, type =
+                    'number'),
+                    html.I(className = 'fa-regular fa-circle-question',
+                       id = 'min-peak-amp-help'),
+                    dbc.Tooltip(
+                        'Exclude SCR peaks with ampitudes below this '
+                        'threshold. If this field is empty, no amplitude '
+                        'threshold is used.',
+                        target = 'min-peak-amp-help')
+                ], hidden = True),
+                html.Div(id = 'valid-amplitude-range', children = [
+                    html.Span('Valid EDA Range (µS):'),
+                    html.Span('Min:'),
+                    dcc.Input(id = 'eda-valid-min', value = 0.2, type = 'number'),
+                    html.Span('Max:'),
+                    dcc.Input(id = 'eda-valid-max', value = 40, type = 'number'),
+                ])
+            ], style = {'padding': '5px 0px 7px 0px'}),
             html.Div(id = 'filter-data', children = [
                 html.Div(id = 'filter-settings', children = [
                     html.Div([
@@ -243,32 +269,6 @@ layout = html.Div(id = 'main', children = [
                     ], style = {'display': 'flex', 'alignItems': 'center'})
                 ]),
             ]),
-            html.Div(id = 'eda-preprocessing', hidden = True, children = [
-                html.Div(id = 'select-scr-detector', children = [
-                    html.Span('SCR Detector:'),
-                    dcc.Dropdown(id = 'scr-detectors',
-                                 options = [], clearable = False)
-                ]),
-                html.Div(id = 'scr-amplitude-threshold', children = [
-                    html.Span('Minimum Peak Amplitude (µS):'),
-                    dcc.Input(id = 'scr-amp-thresh', value = None, type =
-                    'number'),
-                    html.I(className = 'fa-regular fa-circle-question',
-                       id = 'min-peak-amp-help'),
-                    dbc.Tooltip(
-                        'Exclude SCR peaks with ampitudes below this '
-                        'threshold. If this field is empty, no amplitude '
-                        'threshold is used.',
-                        target = 'min-peak-amp-help')
-                ], hidden = True),
-                html.Div(id = 'valid-amplitude-range', children = [
-                    html.Span('Valid EDA Range (µS):'),
-                    html.Span('Min:'),
-                    dcc.Input(id = 'eda-valid-min', value = 0.2, type = 'number'),
-                    html.Span('Max:'),
-                    dcc.Input(id = 'eda-valid-max', value = 40, type = 'number'),
-                ])
-            ], style = {'padding': '5px 0px 7px 0px'}),
             html.Div(id = 'segment-data', children = [
                 html.Span('Segment Size (sec):'),
                 dcc.Input(id = 'seg-size', type = 'number'),
@@ -301,7 +301,7 @@ layout = html.Div(id = 'main', children = [
                         html.Span('Selected filter:', id = 'selected-filter-label'),
                         html.I(className = 'fa-regular fa-circle-question',
                                 id = 'selected-filter-help'),
-                        dbc.Tooltip('Filter type is automaticallly selected based on the data type and selected beat detection method.',
+                        dbc.Tooltip('Filter type is automaticallly selected based on the data type and selected beat/SCR detection method.',
                                     target = 'selected-filter-help',
                                     style = {'--bs-tooltip-max-width': '225px'})
                     ]),

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -340,7 +340,12 @@ layout = html.Div(id = 'main', children = [
                         html.Span('Stopband Attenuation (dB):'),
                         dcc.Input(id = 'filter-rs', type = 'number',
                                     value = 80, min = 0.01),
-                    ])
+                    ]),
+                    html.Div(id = 'filter-window-len-div', className='filter-config-item', children = [
+                        html.Span('Moving Average Window Length (s):'),
+                        dcc.Input(id = 'filter-window-len', type = 'number',
+                                    value = 0.5, min = 0.01),
+                    ]),
                 ]),
                 html.Div(id = 'filter-customization-buttons', children = [
                     html.Button('Apply', n_clicks = 0, id = 'apply-filter-btn'),

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -411,9 +411,17 @@ layout = html.Div(id = 'main', children = [
                 dbc.ModalTitle('Error')
             ], close_button = True),
             dbc.ModalBody([
-                html.Span('An unexpected error occurred:',
+                html.Span('An error occurred while processing the data. Please check the following:',
                           style = {'fontWeight': '600'}),
-                html.Div(id = 'pipeline-error-message', children = [])
+                html.Ul(id = 'pipeline-error-message', children = [
+                    html.Li('The selected data type is correct.'),
+                    html.Li('The configured sampling rate is correct.'),
+                    html.Li('Time/sample and signal columns are mapped correctly.'),
+                    html.Li('The uploaded signal is already filtered or the filter is toggled on. Some beat detectors may not work well with unfiltered signals.'),
+                    html.Li('The custom filter configuration is reasonable.'),
+                    html.Li('The data contains valid signals.'),
+                    html.Li('Try a different beat detector or preprocess the data differently.'),
+                ])
             ])
         ], className = 'validation-error-modal', centered = True),
 

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -290,7 +290,8 @@ layout = html.Div(id = 'main', children = [
         ]),
 
         # Filter Customization
-        dbc.Modal(id = 'filter-customization-modal', is_open = False, children = [
+        dbc.Modal(id = 'filter-customization-modal', is_open = False, keyboard=False,
+            backdrop="static", children = [
             dbc.ModalHeader(children = [
                 dbc.ModalTitle('Advanced Filter Settings')
             ], close_button = False),

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -185,6 +185,13 @@ layout = html.Div(id = 'main', children = [
         ]),
         html.Div(id = 'preprocess-data', hidden = True, children = [
             html.H4('Preprocess Data'),
+            html.Div(id = 'beat-detector-settings', hidden = True, children = [
+                html.Div(id = 'select-beat-detector', children = [
+                    html.Span('Beat Detector:'),
+                    dcc.Dropdown(id = 'beat-detectors',
+                                 options = [], clearable = False)
+                ])
+            ]),
             html.Div(id = 'filter-data', children = [
                 html.Div(id = 'filter-settings', children = [
                     html.Div([
@@ -204,26 +211,25 @@ layout = html.Div(id = 'main', children = [
                                     style = {'--bs-tooltip-max-width': '225px'})
                     ], style = {'display': 'flex', 'alignItems': 'center'}),
                     html.A('Filter Settings', id = 'filter-config-link',
-                           n_clicks = 0, href = '#', hidden = True)
+                            n_clicks = 0, href = '#', hidden = True)
                 ]),
                 html.Div(
                     dbc.Card(dbc.CardBody([
                         html.Div(id = 'lower-cutoff-div', children = [
                             html.Span('Lower Cutoff (Hz):'),
                             dcc.Input(id = 'filter-lowcut', type = 'number',
-                                      value = 1, min = 0.1),
+                                        value = 1, min = 0.1),
                         ]),
                         html.Div(id = 'upper-cutoff-div', children = [
                             html.Span('Upper Cutoff (Hz):'),
                             dcc.Input(id = 'filter-highcut', type = 'number',
-                                      value = 15, min = 0.1),
+                                        value = 15, min = 0.1),
                         ]),
                     ])),
                     id = 'filter-config-collapse',
                     className = 'filter-config-hidden'),
             ]),
-
-            html.Div(id = 'cardio-preprocessing', hidden = True, children = [
+            html.Div(id = 'artifact-settings', hidden = True, children = [
                 html.Div(id = 'artifact-params', children = [
                     html.Div(children = [
                         html.Span('Artifact Identification Method:'),
@@ -251,11 +257,6 @@ layout = html.Div(id = 'main', children = [
                             'detection algorithm. A lower tolerance will lead '
                             'to more artifacts flagged.', target = 'artifact-tol-help')
                     ], style = {'display': 'flex', 'alignItems': 'center'})
-                ]),
-                html.Div(id = 'select-beat-detector', children = [
-                    html.Span('Beat Detector:'),
-                    dcc.Dropdown(id = 'beat-detectors',
-                                 options = [], clearable = False)
                 ]),
             ]),
             html.Div(id = 'eda-preprocessing', hidden = True, children = [
@@ -295,6 +296,7 @@ layout = html.Div(id = 'main', children = [
                     target = 'seg-data-help')
             ]),
         ]),
+
         html.Div(id = 'run-save-buttons', children = [
             html.Button('Run', n_clicks = 0, id = 'run-data', disabled = True),
             html.Button('Stop', n_clicks = 0, id = 'stop-run', hidden = True,

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -236,7 +236,7 @@ layout = html.Div(id = 'main', children = [
                                     target = 'filter-help',
                                     style = {'--bs-tooltip-max-width': '225px'})
                     ], style = {'display': 'flex', 'alignItems': 'center'}),
-                    html.Button('Customize Filter', n_clicks = 0, id = 'filter-config-btn', hidden = True)
+                    html.Button('Advanced Settings', n_clicks = 0, id = 'filter-config-btn', hidden = True)
                 ]),
             ]),
             html.Div(id = 'artifact-settings', hidden = True, children = [
@@ -292,10 +292,10 @@ layout = html.Div(id = 'main', children = [
         # Filter Customization
         dbc.Modal(id = 'filter-customization-modal', is_open = False, children = [
             dbc.ModalHeader(children = [
-                dbc.ModalTitle('Customize Filter')
+                dbc.ModalTitle('Advanced Filter Settings')
             ], close_button = False),
             dbc.ModalBody(children = [
-                html.Span('Customize the filter settings.'),
+                html.Span('Customize the filter settings for more control.'),
                 html.Div(id = 'selected-filter-container', children = [
                     html.Div(children = [
                         html.Span('Selected filter:', id = 'selected-filter-label'),

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -346,6 +346,21 @@ layout = html.Div(id = 'main', children = [
                         dcc.Input(id = 'filter-window-len', type = 'number',
                                     value = 0.5, min = 0.01),
                     ]),
+                    html.Div(id = 'filter-length-div', className='filter-config-item', children = [
+                        html.Span('Filter Length (taps):'),
+                        dcc.Input(id = 'filter-length', type = 'number',
+                                    value = 2057, min = 1),
+                    ]),
+                    html.Div(id = 'filter-window-type-div', className='filter-config-item', children = [
+                        html.Span('Window Type:'),
+                        dcc.Dropdown(id = 'filter-window-type',
+                                    options = [
+                                        {'label': 'Hamming', 'value': 'hamming'},
+                                        {'label': 'Hann', 'value': 'hann'},
+                                        {'label': 'Blackman', 'value': 'blackman'}
+                                    ],
+                                    value = 'hamming', clearable = False),
+                    ]),
                 ]),
                 html.Div(id = 'filter-customization-buttons', children = [
                     html.Button('Apply', n_clicks = 0, id = 'apply-filter-btn'),

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -293,7 +293,7 @@ layout = html.Div(id = 'main', children = [
         dbc.Modal(id = 'filter-customization-modal', is_open = False, children = [
             dbc.ModalHeader(children = [
                 dbc.ModalTitle('Customize Filter')
-            ], close_button = True),
+            ], close_button = False),
             dbc.ModalBody(children = [
                 html.Span('Customize the filter settings.'),
                 html.Div(id = 'selected-filter-container', children = [
@@ -314,7 +314,14 @@ layout = html.Div(id = 'main', children = [
                         dbc.Tooltip('Parameters used in the original paper of the selected beat detector are selected by default. \
                                     Customize the filter parameters to your data.',
                                     target = 'filter-parameters-help',
-                                    style = {'--bs-tooltip-max-width': '225px'})
+                                    style = {'--bs-tooltip-max-width': '225px'}),
+                        html.A('Reset to Default', href = '#', id = 'reset-to-default-btn')
+                    ]),
+                    html.Div(id = 'empty-param-error-div', className='filter-config-error', hidden = True, children = [
+                        html.Span('One or more filter parameters are empty. Please fill in all parameters.')
+                    ]),
+                    html.Div(id = 'lowcut-highcut-error-div', className='filter-config-error', hidden = True, children = [
+                        html.Span('Lower cutoff must be less than upper cutoff.')
                     ]),
                     html.Div(id = 'lower-cutoff-div', className='filter-config-item', children = [
                         html.Span('Lower Cutoff (Hz):'),
@@ -364,7 +371,7 @@ layout = html.Div(id = 'main', children = [
                 ]),
                 html.Div(id = 'filter-customization-buttons', children = [
                     html.Button('Apply', n_clicks = 0, id = 'apply-filter-btn'),
-                    html.Button('Reset', n_clicks = 0, id = 'reset-config-btn'),
+                    html.Button('Cancel', n_clicks = 0, id = 'cancel-config-btn'),
                 ])
             ])
         ], centered = True),

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -335,7 +335,7 @@ layout = html.Div(id = 'main', children = [
                     ]),
                     html.Div(id = 'filter-order-div', className='filter-config-item', children = [
                         html.Span('Filter Order:'),
-                        dcc.Input(id = 'filter-order', type = 'number',
+                        dcc.Input(id = 'filter-order', type = 'number', step = 1,
                                     value = 2, min = 1),
                     ]),
                     html.Div(id = 'filter-rp-div', className='filter-config-item', children = [

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -193,9 +193,9 @@ layout = html.Div(id = 'main', children = [
                             color = '#ee8a78',
                             label = 'Filter Signal',
                             labelPosition = 'left',
-                            on = False),
+                            on = True),
                         html.I(className = 'fa-regular fa-circle-question',
-                               id = 'filter-help'),
+                                id = 'filter-help'),
                         dbc.Tooltip('Apply a filter to remove low- and '
                                     'high-frequency noise, including baseline '
                                     'drift, powerline interference, '

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -210,39 +210,8 @@ layout = html.Div(id = 'main', children = [
                                     target = 'filter-help',
                                     style = {'--bs-tooltip-max-width': '225px'})
                     ], style = {'display': 'flex', 'alignItems': 'center'}),
-                    html.A('Filter Settings', id = 'filter-config-link',
-                            n_clicks = 0, href = '#', hidden = True)
+                    html.Button('Customize Filter', n_clicks = 0, id = 'filter-config-btn', hidden = True)
                 ]),
-                html.Div(
-                    dbc.Card(dbc.CardBody([
-                        html.Div(id = 'lower-cutoff-div', children = [
-                            html.Span('Lower Cutoff (Hz):'),
-                            dcc.Input(id = 'filter-lowcut', type = 'number',
-                                        value = 1, min = 0.1),
-                        ]),
-                        html.Div(id = 'upper-cutoff-div', children = [
-                            html.Span('Upper Cutoff (Hz):'),
-                            dcc.Input(id = 'filter-highcut', type = 'number',
-                                        value = 15, min = 0.1),
-                        ]),
-                        html.Div(id = 'filter-order-div', children = [
-                            html.Span('Filter Order:'),
-                            dcc.Input(id = 'filter-order', type = 'number',
-                                        value = 2, min = 1),
-                        ]),
-                        html.Div(id = 'filter-rp-div', children = [
-                            html.Span('Passband Ripple (dB):'),
-                            dcc.Input(id = 'filter-rp', type = 'number',
-                                        value = 0.15, min = 0.01),
-                        ]),
-                        html.Div(id = 'filter-rs-div', children = [
-                            html.Span('Stopband Attenuation (dB):'),
-                            dcc.Input(id = 'filter-rs', type = 'number',
-                                        value = 80, min = 0.01),
-                        ]),
-                    ])),
-                    id = 'filter-config-collapse',
-                    className = 'filter-config-hidden'),
             ]),
             html.Div(id = 'artifact-settings', hidden = True, children = [
                 html.Div(id = 'artifact-params', children = [
@@ -319,6 +288,66 @@ layout = html.Div(id = 'main', children = [
             html.Button('Save', n_clicks = 0, id = 'configure',
                         disabled = True)
         ]),
+
+        # Filter Customization
+        dbc.Modal(id = 'filter-customization-modal', is_open = False, children = [
+            dbc.ModalHeader(children = [
+                dbc.ModalTitle('Customize Filter')
+            ], close_button = True),
+            dbc.ModalBody(children = [
+                html.Span('Customize the filter settings.'),
+                html.Div(id = 'selected-filter-container', children = [
+                    html.Div(children = [
+                        html.Span('Selected filter:', id = 'selected-filter-label'),
+                        html.I(className = 'fa-regular fa-circle-question',
+                                id = 'selected-filter-help'),
+                        dbc.Tooltip('Filter type is automaticallly selected based on the data type and selected beat detection method.',
+                                    target = 'selected-filter-help',
+                                    style = {'--bs-tooltip-max-width': '225px'})
+                    ]),
+                    html.Span('Please select the signal type to customize the filter settings.', id = 'selected-filter'),
+                ]),
+                html.Div(id = 'filter-parameters-container', children = [html.Div(children = [
+                        html.Span('Filter Parameters:', id = 'filter-parameters-label'),
+                        html.I(className = 'fa-regular fa-circle-question',
+                                id = 'filter-parameters-help'),
+                        dbc.Tooltip('Parameters used in the original paper of the selected beat detector are selected by default. \
+                                    Customize the filter parameters to your data.',
+                                    target = 'filter-parameters-help',
+                                    style = {'--bs-tooltip-max-width': '225px'})
+                    ]),
+                    html.Div(id = 'lower-cutoff-div', className='filter-config-item', children = [
+                        html.Span('Lower Cutoff (Hz):'),
+                        dcc.Input(id = 'filter-lowcut', type = 'number',
+                                    value = 1, min = 0.1),
+                    ]),
+                    html.Div(id = 'upper-cutoff-div', className='filter-config-item', children = [
+                        html.Span('Upper Cutoff (Hz):'),
+                        dcc.Input(id = 'filter-highcut', type = 'number',
+                                    value = 15, min = 0.1),
+                    ]),
+                    html.Div(id = 'filter-order-div', className='filter-config-item', children = [
+                        html.Span('Filter Order:'),
+                        dcc.Input(id = 'filter-order', type = 'number',
+                                    value = 2, min = 1),
+                    ]),
+                    html.Div(id = 'filter-rp-div', className='filter-config-item', children = [
+                        html.Span('Passband Ripple (dB):'),
+                        dcc.Input(id = 'filter-rp', type = 'number',
+                                    value = 0.15, min = 0.01),
+                    ]),
+                    html.Div(id = 'filter-rs-div', className='filter-config-item', children = [
+                        html.Span('Stopband Attenuation (dB):'),
+                        dcc.Input(id = 'filter-rs', type = 'number',
+                                    value = 80, min = 0.01),
+                    ])
+                ]),
+                html.Div(id = 'filter-customization-buttons', children = [
+                    html.Button('Apply', n_clicks = 0, id = 'apply-filter-btn'),
+                    html.Button('Reset', n_clicks = 0, id = 'reset-config-btn'),
+                ])
+            ])
+        ], centered = True),
 
         # Variable Mappings Validator
         dbc.Modal(id = 'mapping-validator', is_open = False, children = [

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -225,6 +225,21 @@ layout = html.Div(id = 'main', children = [
                             dcc.Input(id = 'filter-highcut', type = 'number',
                                         value = 15, min = 0.1),
                         ]),
+                        html.Div(id = 'filter-order-div', children = [
+                            html.Span('Filter Order:'),
+                            dcc.Input(id = 'filter-order', type = 'number',
+                                        value = 2, min = 1),
+                        ]),
+                        html.Div(id = 'filter-rp-div', children = [
+                            html.Span('Passband Ripple (dB):'),
+                            dcc.Input(id = 'filter-rp', type = 'number',
+                                        value = 0.15, min = 0.01),
+                        ]),
+                        html.Div(id = 'filter-rs-div', children = [
+                            html.Span('Stopband Attenuation (dB):'),
+                            dcc.Input(id = 'filter-rs', type = 'number',
+                                        value = 80, min = 0.01),
+                        ]),
                     ])),
                     id = 'filter-config-collapse',
                     className = 'filter-config-hidden'),

--- a/physioview/dashboard/utils.py
+++ b/physioview/dashboard/utils.py
@@ -61,6 +61,7 @@ def _default_filter_params(dtype: str, beat_detector: str) -> tuple:
     order = None
     rp = None
     rs = None
+    window_len = None
     filt_type = None
     if dtype == 'ECG':
         if beat_detector == 'engzee':
@@ -90,13 +91,15 @@ def _default_filter_params(dtype: str, beat_detector: str) -> tuple:
     elif dtype == 'PPG':
         lowcut = 0.5
         highcut = 10
-        filt_type = 'Chebyshev Type II filter'
+        order = 4
+        window_len = 0.5
+        filt_type = 'Chebyshev Type II filter with moving average smoothing'
     elif dtype == 'EDA':
         highcut = 0.35
         filt_type = 'FIR low-pass filter'
     else:
         raise ValueError(f'Invalid data type: {dtype}')
-    return lowcut, highcut, order, rp, rs, filt_type
+    return lowcut, highcut, order, rp, rs, window_len, filt_type
 
 def _preprocess_cardiac(
     data: pd.DataFrame,
@@ -110,8 +113,9 @@ def _preprocess_cardiac(
     filter_lowcut: float = None,
     filter_highcut: float = None,
     order: Optional[int] = None,
-    rs: Optional[float] = None,
     rp: Optional[float] = None,
+    rs: Optional[float] = None,
+    window_len: Optional[float] = None,
     acc_data: Optional[pd.DataFrame] = None,
     downsample: bool = True
 ) -> tuple:
@@ -158,13 +162,14 @@ def _preprocess_cardiac(
     elif dtype in ('PPG', 'BVP'):
         filt = PPG.Filters(fs)
         detect_beats = PPG.BeatDetectors(fs, is_preprocessed)
-
-    # Filter ECG
-    if filter_on:
-        preprocessed_data['Filtered'] = filt.filter_signal(
-            preprocessed_data[dtype],
-            lowcut = filter_lowcut,
-            highcut = filter_highcut)
+        # Filter PPG
+        if filter_on:
+            preprocessed_data['Filtered'] = filt.filter_signal(
+                preprocessed_data[dtype],
+                lowcut = filter_lowcut if filter_lowcut is not None else 0.5,
+                highcut = filter_highcut if filter_highcut is not None else 10,
+                order = order if order is not None else 4,
+                window_len = window_len if window_len is not None else 0.5)
 
     # Segment data and detect beats by segment
     preprocessed_data.insert(

--- a/physioview/dashboard/utils.py
+++ b/physioview/dashboard/utils.py
@@ -63,21 +63,57 @@ def _preprocess_cardiac(
     artifact_method: str,
     artifact_tol: float,
     filter_on: bool,
-    filter_lowcut: float = 1,
-    filter_highcut: float = 15,
+    filter_lowcut: float = None,
+    filter_highcut: float = None,
+    order: Optional[int] = None,
+    rs: Optional[float] = None,
+    rp: Optional[float] = None,
     acc_data: Optional[pd.DataFrame] = None,
     downsample: bool = True
 ) -> tuple:
     """Run the PhysioView pipeline on ECG/PPG data."""
-    is_preprocessed = False if not filter_on else True
+    is_preprocessed = True
+    preprocessed_data = data.copy()
+
     if dtype == 'ECG':
         filt = ECG.Filters(fs)
         detect_beats = ECG.BeatDetectors(fs, is_preprocessed)
+        if filter_on:
+            if beat_detector == 'engzee':
+                preprocessed_data['Filtered'] = filt.filter_signal(
+                preprocessed_data[dtype],
+                lowcut = filter_lowcut if filter_lowcut is not None else 1,
+                highcut = filter_highcut if filter_highcut is not None else 15,
+            )
+            elif beat_detector == 'manikandan':
+                preprocessed_data['Filtered'] = filt.cheby1_filter(
+                    signal=preprocessed_data[dtype],
+                    lowcut = filter_lowcut if filter_lowcut is not None else 6,
+                    highcut = filter_highcut if filter_highcut is not None else 18,
+                    order=order if order is not None else 4,
+                    rp=rp if rp is not None else 1,
+                )
+            elif beat_detector == 'nabian':
+                preprocessed_data['Filtered'] = filt.elliptic_bandpass_filter(
+                    signal=preprocessed_data[dtype],
+                    lowcut = filter_lowcut if filter_lowcut is not None else 0.5,
+                    highcut = filter_highcut if filter_highcut is not None else 50,
+                    order = order if order is not None else 2,
+                    rs = rs if rs is not None else 0.5,
+                    rp = rp if rp is not None else 40,
+                )
+            elif beat_detector == 'pantompkins':
+                preprocessed_data['Filtered'] = filt.butter_bandpass_filter(
+                    signal=preprocessed_data[dtype],
+                    lowcut = filter_lowcut if filter_lowcut is not None else 0.5,
+                    highcut = filter_highcut if filter_highcut is not None else 15,
+                    order = order if order is not None else 2,
+                )
+            else:
+                raise ValueError(f'Invalid beat detector: {beat_detector}')
     elif dtype in ('PPG', 'BVP'):
         filt = PPG.Filters(fs)
         detect_beats = PPG.BeatDetectors(fs, is_preprocessed)
-
-    preprocessed_data = data.copy()
 
     # Filter ECG
     if filter_on:

--- a/physioview/dashboard/utils.py
+++ b/physioview/dashboard/utils.py
@@ -54,6 +54,50 @@ def _clear_edits():
                 rmtree(item)
 
 # ======================= HearView Pipeline Functions ========================
+def _default_filter_params(dtype: str, beat_detector: str) -> tuple:
+    """Return the default filter parameters for a given data type and beat detector."""
+    lowcut = None
+    highcut = None
+    order = None
+    rp = None
+    rs = None
+    filt_type = None
+    if dtype == 'ECG':
+        if beat_detector == 'engzee':
+            lowcut = 1
+            highcut = 15
+            filt_type = 'Elliptic bandpass filter'
+        elif beat_detector == 'manikandan':
+            lowcut = 6
+            highcut = 18
+            order = 4
+            rp = 1
+            filt_type = 'Chebyshev Type I bandpass filter'
+        elif beat_detector == 'nabian':
+            lowcut = 0.5
+            highcut = 50
+            order = 2
+            rp = 0.5
+            filt_type = 'Elliptic bandpass filter'
+            rs = 40
+        elif beat_detector == 'pantompkins':
+            lowcut = 0.5
+            highcut = 15
+            order = 2
+            filt_type = 'Butterworth bandpass filter'
+        else:
+            raise ValueError(f'Invalid beat detector: {beat_detector}')
+    elif dtype == 'PPG':
+        lowcut = 0.5
+        highcut = 10
+        filt_type = 'Chebyshev Type II filter'
+    elif dtype == 'EDA':
+        highcut = 0.35
+        filt_type = 'FIR low-pass filter'
+    else:
+        raise ValueError(f'Invalid data type: {dtype}')
+    return lowcut, highcut, order, rp, rs, filt_type
+
 def _preprocess_cardiac(
     data: pd.DataFrame,
     dtype: str,

--- a/physioview/dashboard/utils.py
+++ b/physioview/dashboard/utils.py
@@ -339,7 +339,7 @@ def _preprocess_eda(
     if filter_on:
         filter_eda = EDA.Filters(fs)
         preprocessed_data['Filtered'] = filter_eda.filter_signal(
-            preprocessed_data['EDA'], fs = fs, cutoff = filter_highcut)
+            preprocessed_data['EDA'], cutoff = filter_highcut)
         is_preprocessed = True
         if temp is not None:
             preprocessed_data['TEMP'] = filter_eda.moving_average(

--- a/physioview/dashboard/utils.py
+++ b/physioview/dashboard/utils.py
@@ -62,6 +62,8 @@ def _default_filter_params(dtype: str, beat_detector: str) -> tuple:
     rp = None
     rs = None
     window_len = None
+    filter_length = None
+    window_type = None
     filt_type = None
     if dtype == 'ECG':
         if beat_detector == 'engzee':
@@ -96,10 +98,12 @@ def _default_filter_params(dtype: str, beat_detector: str) -> tuple:
         filt_type = 'Chebyshev Type II filter with moving average smoothing'
     elif dtype == 'EDA':
         highcut = 0.35
+        filter_length = 2057
+        window_type = 'hamming'
         filt_type = 'FIR low-pass filter'
     else:
         raise ValueError(f'Invalid data type: {dtype}')
-    return lowcut, highcut, order, rp, rs, window_len, filt_type
+    return lowcut, highcut, order, rp, rs, window_len, filter_length, window_type, filt_type
 
 def _preprocess_cardiac(
     data: pd.DataFrame,

--- a/physioview/pipeline/ECG.py
+++ b/physioview/pipeline/ECG.py
@@ -178,7 +178,7 @@ class Filters:
         nyquist = 0.5 * self.fs
         low = lowcut / nyquist
         high = highcut / nyquist
-        b, a = butter(N = 2, Wn = [low, high], btype = 'band')
+        b, a = butter(N = order, Wn = [low, high], btype = 'band')
         preprocessed = filtfilt(b, a, signal)
         return preprocessed
 

--- a/physioview/pipeline/ECG.py
+++ b/physioview/pipeline/ECG.py
@@ -137,6 +137,91 @@ class Filters:
         b, a = iirnotch(w0, q)
         filtered = filtfilt(b, a, signal)
         return filtered
+    
+    def ma_cumulative_sum(
+        self,
+        signal: np.ndarray,
+        window_len: int
+    ) -> np.ndarray:
+        """Moving average filter using cumulative sums."""
+        cumsum = np.cumsum(np.insert(signal, 0, 0))
+        ma = (cumsum[window_len:] - cumsum[:-window_len]) / float(window_len)
+        return ma
+
+    def ma_convolution(
+        self,
+        signal: np.ndarray,
+        window_len: int
+    ) -> np.ndarray:
+        """Moving average filter using convolution."""
+        padded_diff = np.pad(
+            signal, (window_len // 2, window_len // 2), mode = 'constant')
+        ma = np.convolve(
+            padded_diff, np.ones(window_len) / window_len, mode = 'valid')
+        return ma
+
+    def butter_bandpass_filter(
+        self,
+        signal: np.ndarray,
+        lowcut: float = 0.5,
+        highcut: float = 15,
+        order: int = 2
+    ) -> np.ndarray:
+        """A Butterworth bandpass filter, used in the preprocessing procedure
+        of the Pan & Tompkins (1985) and Hamilton & Tompkins (1986) QRS
+        detection algorithms. All parameters, including the passband frequency
+        range (`Wn`) and order (`N`) of the filter, are provided as default
+        values according to the Pan & Tompkins (1985) algorithms. To use the same
+        configuration with Hamilton & Tompkins (1986), set lowcut to 8Hz and
+        highcut to 16Hz.
+        """
+        nyquist = 0.5 * self.fs
+        low = lowcut / nyquist
+        high = highcut / nyquist
+        b, a = butter(N = 2, Wn = [low, high], btype = 'band')
+        preprocessed = filtfilt(b, a, signal)
+        return preprocessed
+
+    def elliptic_bandpass_filter(
+        self,
+        signal: np.ndarray,
+        lowcut: float = 0.5,
+        highcut: float = 50,
+        order: int = 2,
+        rs: float = 0.5,
+        rp: float = 40
+    ) -> np.ndarray:
+        """An elliptic bandpass filter, used in the preprocessing procedure
+        of the Nabian et al. (2018) R peak detection algorithm. All parameters,
+        including the lower and upper cutoff frequencies (`Wn`), passband
+        ripple (`rp`), stopband attenuation (`rs`), and order (`N`) of the
+        filter, are provided as default values according to the algorithm."""
+        nyq = 0.5 * self.fs
+        low = lowcut / nyq
+        high = highcut / nyq
+        b, a = ellip(N = order, rs = rs, rp = rp, Wn = [low, high], btype = 'band')
+        preprocessed = filtfilt(b, a, signal)
+        return preprocessed
+
+    def cheby1_filter(
+        self,
+        signal: np.ndarray,
+        lowcut: float = 6,
+        highcut: float = 18,
+        order: int = 4,
+        rp: float = 1
+    ) -> np.ndarray:
+        """A Chebyshev Type I bandpass filter, used in the preprocessing
+        procedure of the Manikandan and Soman (2012) beat detection algorithm.
+        All parameters, including the lower and upper cutoff frequencies
+        (`Wn`), passband ripple (`rp`), and order (`N`), of the filter are
+        provided as default values according to the algorithm."""
+        nyquist = 0.5 * self.fs
+        low = lowcut / nyquist
+        high = highcut / nyquist
+        b, a = cheby1(N = order, rp = rp, Wn = [low, high], btype = 'bandpass')
+        preprocessed = filtfilt(b, a, signal)
+        return preprocessed
 
     def filter_signal(
         self,
@@ -199,7 +284,7 @@ class Filters:
 
         filtered = filtfilt(b, a, signal)
         return filtered
-
+    
 # ======================= ECG Beat Detection Methods =========================
 class BeatDetectors:
     """
@@ -454,7 +539,8 @@ class BeatDetectors:
             return passing_beats
 
         if not self.preprocessed:
-            signal = self._cheby1_filter(signal)
+            filter = Filters(self.fs)
+            signal = filter.cheby1_filter(signal)
         else:
             pass
         signal = np.array(signal)
@@ -480,7 +566,8 @@ class BeatDetectors:
         window_len = int(0.15 * self.fs)
 
         # Apply a moving average filter to the energy values
-        sn_f = np.insert(self._ma_cumulative_sum(sn, window_len),
+        filter = Filters(self.fs)
+        sn_f = np.insert(filter.ma_cumulative_sum(sn, window_len),
                          0, [0] * (window_len - 1))
 
         # Apply the Hilbert transform to the filtered energy values
@@ -491,7 +578,7 @@ class BeatDetectors:
         # 2.5 sec in 500 Hz == 1250 samples
         ma_len = int(self.fs * 2.5)
         zn_ma = np.insert(
-            self._ma_cumulative_sum(zn, ma_len), 0, [0] * (ma_len - 1))
+            filter.ma_cumulative_sum(zn, ma_len), 0, [0] * (ma_len - 1))
 
         # Compute the difference to get only the high-frequency components
         zn_ma_s = zn - zn_ma
@@ -552,7 +639,8 @@ class BeatDetectors:
         """
 
         if not self.preprocessed:
-            signal = self._elliptic_bandpass_filter(signal)
+            filter = Filters(self.fs)
+            signal = filter.elliptic_bandpass_filter(signal)
         else:
             pass
 
@@ -569,7 +657,10 @@ class BeatDetectors:
 
     def pantompkins(
         self,
-        signal: np.ndarray
+        signal: np.ndarray,
+        lowcut: float = 0.5,
+        highcut: float = 15,
+        order: int = 2
     ) -> np.ndarray:
         """
         Extract QRS complex locations from an ECG signal with the
@@ -592,7 +683,8 @@ class BeatDetectors:
         """
 
         if not self.preprocessed:
-            signal = self._butter_bandpass_filter(signal, method = 'pan')
+            filter = Filters(self.fs)
+            signal = filter.butter_bandpass_filter(signal, lowcut=lowcut, highcut=highcut, order=order)
         else:
             pass
 
@@ -673,93 +765,6 @@ class BeatDetectors:
 
         ecg_beats = self._remove_dupes(ecg_beats)
         return ecg_beats
-
-    def _ma_cumulative_sum(
-        self,
-        signal: np.ndarray,
-        window_len: int
-    ) -> np.ndarray:
-        """Moving average filter using cumulative sums."""
-        cumsum = np.cumsum(np.insert(signal, 0, 0))
-        ma = (cumsum[window_len:] - cumsum[:-window_len]) / float(window_len)
-        return ma
-
-    def _ma_convolution(
-        self,
-        signal: np.ndarray,
-        window_len: int
-    ) -> np.ndarray:
-        """Moving average filter using convolution."""
-        padded_diff = np.pad(
-            signal, (window_len // 2, window_len // 2), mode = 'constant')
-        ma = np.convolve(
-            padded_diff, np.ones(window_len) / window_len, mode = 'valid')
-        return ma
-
-    def _butter_bandpass_filter(
-        self,
-        signal: np.ndarray,
-        method: str
-    ) -> np.ndarray:
-        """A Butterworth bandpass filter, used in the preprocessing procedure
-        of the Pan & Tompkins (1985) and Hamilton & Tompkins (1986) QRS
-        detection algorithms. All parameters, including the passband frequency
-        range (`Wn`) and order (`N`) of the filter, are provided as default
-        values according to the algorithms."""
-        if method not in ['pan', 'hamilton']:
-            raise ValueError('The `method` parameter must take either \'pan\' '
-                             'or \'hamilton\'.')
-        else:
-            if method == 'pan':
-                lowcut = 0.5
-                highcut = 15
-            if method == 'hamilton':
-                # Based on https://github.com/berndporr/py-ecg-detectors/
-                lowcut = 8
-                highcut = 16
-
-        nyquist = 0.5 * self.fs
-        low = lowcut / nyquist
-        high = highcut / nyquist
-        b, a = butter(N = 2, Wn = [low, high], btype = 'band')
-        preprocessed = filtfilt(b, a, signal)
-        return preprocessed
-
-    def _elliptic_bandpass_filter(
-        self,
-        signal: np.ndarray
-    ) -> np.ndarray:
-        """An elliptic bandpass filter, used in the preprocessing procedure
-        of the Nabian et al. (2018) R peak detection algorithm. All parameters,
-        including the lower and upper cutoff frequencies (`Wn`), passband
-        ripple (`rp`), stopband attenuation (`rs`), and order (`N`) of the
-        filter, are provided as default values according to the algorithm."""
-        nyq = 0.5 * self.fs
-        lowcut = 0.5
-        highcut = 50
-        low = lowcut / nyq
-        high = highcut / nyq
-        b, a = ellip(N = 2, rs = 0.5, rp = 40, Wn = [low, high], btype = 'band')
-        preprocessed = filtfilt(b, a, signal)
-        return preprocessed
-
-    def _cheby1_filter(
-        self,
-        signal: np.ndarray
-    ) -> np.ndarray:
-        """A Chebyshev Type I bandpass filter, used in the preprocessing
-        procedure of the Manikandan and Soman (2012) beat detection algorithm.
-        All parameters, including the lower and upper cutoff frequencies
-        (`Wn`), passband ripple (`rp`), and order (`N`), of the filter are
-        provided as default values according to the algorithm."""
-        nyquist = 0.5 * self.fs
-        lowcut = 6
-        highcut = 18
-        low = lowcut / nyquist
-        high = highcut / nyquist
-        b, a = cheby1(N = 4, rp = 1, Wn = [low, high], btype = 'bandpass')
-        preprocessed = filtfilt(b, a, signal)
-        return preprocessed
 
     def _remove_dupes(
         self,


### PR DESCRIPTION
### Link to issue
- Closes: #57 

### Summary
The original dashboard still applies a filter before detecting beats to ensure the beat-detection algorithm performs reasonably well. This PR disables filtering when users toggle it off, and keeps it on by default to avoid unintended filtering. A filter customization button has also been added, which opens a pop-up modal that lets users customize filtering parameters. Default filtering methods and parameters are selected based on the selected beat detection method, and switching the beat detector updates the parameters.