### PR TITLE
bug DB-6 resolved

### DIFF
--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -1668,11 +1668,6 @@ def get_callbacks(app):
                         del data_edited['Artifact']
                     data_edited.loc[artifacts_edited, 'Artifact'] = 1
 
-                    # Save edited data
-                    data_edited.to_csv(
-                        str(temp_path / f'{selected_subject}_edited.csv'),
-                        index = False)
-
                     # Recompute IBIs with edited beats for rendering
                     ibi_edited = physioview.compute_ibis(
                         data_edited, fs, data_edited_beats_ix, ts_col)
@@ -1686,7 +1681,7 @@ def get_callbacks(app):
                             ends = [unusable_ix[-1]]
                         else:
                             starts = np.insert(unusable_ix[breaks + 1], 0, unusable_ix[0])
-                            ends = np.insert(unusable_ix[breaks], 0, unusable_ix[-1])
+                            ends = np.append(unusable_ix[breaks], unusable_ix[-1])
 
                         unusable_bounds = list(zip(starts, ends))
                         for s, e in unusable_bounds:
@@ -1706,7 +1701,12 @@ def get_callbacks(app):
                                 ibi_edited.loc[ibi_post_ix] = np.nan
                             if artif_post_ix is not None:
                                 data_edited.loc[artif_post_ix, 'Artifact'] = np.nan
-
+                    
+                    # Save edited data
+                    data_edited.to_csv(
+                        str(temp_path / f'{selected_subject}_edited.csv'),
+                        index = False)
+                    
                     # Render updated signal plots
                     signal_plots = physioview.plot_signal(
                         signal = data_edited, signal_type = data_type,


### PR DESCRIPTION
The sync between signal view and the bar chart after marking unusable data is established.

Two bugs caused this:

- ends array was built with np.insert instead of np.append, causing segment boundaries to be mismatched when multiple unusable segments existed and so artifact cleanup ran on wrong index ranges.
- data_edited was saved to disk before the unusable cleanup ran, so the chart and signal view were reading from two different states of the same data.

Fix:

- Changed np.insert to np.append when constructing ends to correctly pair segment boundaries.
- Moved data_edited.to_csv() to after the cleanup block so both views reflect the same state.
<img width="3816" height="1510" alt="bug DB-6" src="https://github.com/user-attachments/assets/961cb540-42dc-4cd5-ba9d-816ea9d138a7" />
