### PR TITLE
[DB-6] Artifact count not syncing between signal view and data quality chart

### DIFF
--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -1830,11 +1830,6 @@ def get_callbacks(app):
                         del data_edited['Artifact']
                     data_edited.loc[artifacts_edited, 'Artifact'] = 1
 
-                    # Save edited data
-                    data_edited.to_csv(
-                        str(temp_path / f'{selected_subject}_edited.csv'),
-                        index = False)
-
                     # Recompute IBIs with edited beats for rendering
                     ibi_edited = physioview.compute_ibis(
                         data_edited, fs, data_edited_beats_ix, ts_col)
@@ -1848,7 +1843,7 @@ def get_callbacks(app):
                             ends = [unusable_ix[-1]]
                         else:
                             starts = np.insert(unusable_ix[breaks + 1], 0, unusable_ix[0])
-                            ends = np.insert(unusable_ix[breaks], 0, unusable_ix[-1])
+                            ends = np.append(unusable_ix[breaks], unusable_ix[-1])
 
                         unusable_bounds = list(zip(starts, ends))
                         for s, e in unusable_bounds:
@@ -1869,6 +1864,11 @@ def get_callbacks(app):
                             if artif_post_ix is not None:
                                 data_edited.loc[artif_post_ix, 'Artifact'] = np.nan
 
+                    # Save edited data
+                    data_edited.to_csv(
+                        str(temp_path / f'{selected_subject}_edited.csv'),
+                        index = False)
+                        
                     # Render updated signal plots
                     signal_plots = physioview.plot_signal(
                         signal = data_edited, signal_type = data_type,


### PR DESCRIPTION
### Summary

When beats are marked as unusable in the Beat Editor, the artifact count displayed in the Data Quality chart does not match the artifact markers shown in the Signal View. 

This is caused by two bugs in callbacks.py:

- The ends array was built using np.insert instead of np.append, causing segment boundaries to be mismatched when multiple unusable segments exist basically, artifact cleanup ran on the wrong index ranges.

- data_edited was saved to disk before the unusable segment cleanup ran, so the chart and signal view were reading from two different states of the same data.

Fix:

- Changed np.insert to np.append when constructing ends to correctly pair segment boundaries.

- Moved data_edited.to_csv() to after the cleanup block so both views reflect the same state.
not done

Acceptance Criteria:

- [ ] Artifact count in the Data Quality chart matches the artifact markers in the Signal View after marking beats as unusable

- [ ] Segment boundaries are correctly paired when multiple unusable segments exist

<img width="3816" height="1510" alt="bug DB-6" src="https://github.com/user-attachments/assets/ffe8d599-52b1-49ce-9115-20ce127486c6" />