### PR TITLE
DB-12: Add support for peak detection mode selection

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -85,7 +85,7 @@ h6 {
     padding: 0px 0px 5px 3px;
     /*margin-bottom: -45px;*/
 }
-#select-subject i {
+#select-subject i, #select-event i {
     font-size: 14pt;
 }
 #qa-section {
@@ -331,30 +331,39 @@ h6 {
 }
 #select-beat-detector {
     margin-top: 5px;
-    padding-bottom: 10px;
+    padding-bottom: 5px;
 }
 #select-scr-detector {
-    padding-bottom: 10px;
+    padding-bottom: 5px;
 }
 #select-beat-detector > span, #select-beat-detector > div > span,
-#select-scr-detector > span {
+#select-scr-detector > span, #peak-detection-mode-div > span {
     font-weight: 600;
     white-space: nowrap;
 }
 #beat-detectors {
     margin-top: 5px;
 }
+#peak-detection-mode-div {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: nowrap;
+    margin-top: 5px;
+    margin-bottom: 10px;
+    justify-content: space-between;
+}
 #peak-detection-mode {
     display: inline-flex;
 }
 #peak-detection-mode label {
-    padding-right: 10px;
+    padding-right: 7px;
     margin-left: 7px;
     white-space: nowrap;
     font-size: 10pt;
 }
 #detection-mode-help {
-    margin-left: -10px;
+    margin-left: -6px;
     font-size: 13pt;
 }
 #event-segmentation-options, #beat-detectors, #scr-detectors {

--- a/assets/style.css
+++ b/assets/style.css
@@ -336,8 +336,26 @@ h6 {
 #select-scr-detector {
     padding-bottom: 10px;
 }
-#select-beat-detector > span, #select-scr-detector > span {
+#select-beat-detector > span, #select-beat-detector > div > span,
+#select-scr-detector > span {
     font-weight: 600;
+    white-space: nowrap;
+}
+#beat-detectors {
+    margin-top: 5px;
+}
+#peak-detection-mode {
+    display: inline-flex;
+}
+#peak-detection-mode label {
+    padding-right: 10px;
+    margin-left: 7px;
+    white-space: nowrap;
+    font-size: 10pt;
+}
+#detection-mode-help {
+    margin-left: -10px;
+    font-size: 13pt;
 }
 #event-segmentation-options, #beat-detectors, #scr-detectors {
     font-size: 10pt;

--- a/physioview/dashboard/_core/preprocessing.py
+++ b/physioview/dashboard/_core/preprocessing.py
@@ -18,7 +18,10 @@ class Preprocessor:
         Whether the signal should be filtered. This corresponds to the
         state of the BooleanSwitch component with the ID 'toggle-filter'.
     peak_detector : str, optional
-            The name of peak detection algorithm to use.
+        The name of peak detection algorithm to use.
+    peak_detection_mode : str, optional
+        Whether to detect beats across the entire signal or on a
+        segment-by-segment basis. Must be either 'entire' or 'segment'.
     event_times : pd.DataFrame
         A DataFrame containing the uploaded event onsets and offsets,
         if any. If provided, must contain the columns: "event" (str),
@@ -65,6 +68,7 @@ class Preprocessor:
         fs: int,
         filter_on: bool,
         peak_detector: Optional[str] = None,
+        peak_detection_mode: str = 'entire',
         event_times: Optional[pd.DataFrame] = None,
         seg_size: Optional[int] = None,
         filter_kwargs: Optional[dict] = None
@@ -84,6 +88,9 @@ class Preprocessor:
             state of the BooleanSwitch component with the ID 'toggle-filter'.
         peak_detector : str, optional
             The name of peak detection algorithm to use.
+        peak_detection_mode : str, optional
+            Whether to detect beats across the entire signal or on a
+            segment-by-segment basis. Must be either 'entire' or 'segment'.
         event_times : pd.DataFrame
             A DataFrame containing the uploaded event onsets and offsets,
             if any. If provided, must contain the columns: "event" (str),
@@ -104,10 +111,15 @@ class Preprocessor:
         self.fs = fs
         self.filter_on = filter_on
         self.peak_detector = peak_detector or self._get_default_peak_detector()
+        self.peak_detection_mode = peak_detection_mode
         self.event_times = event_times
         self.seg_size = seg_size
         self.filter_kwargs = filter_kwargs or {}
         self.duration = None
+
+        if self.peak_detection_mode == 'segment' and self.seg_size is None:
+            raise ValueError(
+                "seg_size is required when peak_detection_mode is 'segment'.")
 
         # Initialize storage for peak and artifact indices
         self.peaks_ix = None
@@ -190,19 +202,28 @@ class Preprocessor:
             signal_col = 'Phasic'
 
         # Segment the data
-        data_segments = self._segment_data(preprocessed)
+        if self.seg_size is not None:
+            preprocessed = self._segment_data(preprocessed)
 
         # Process each segment
-        for seg_label, seg_data in data_segments.groupby('Segment'):
+        if self.peak_detection_mode == 'segment':
+            for seg_label, seg_data in preprocessed.groupby('Segment'):
 
-            # Detect peaks in the window
-            seg_peaks, peak_label = self._detect_peaks(
-                seg_data[signal_col],
-                min_peak_amp = min_peak_amp if self.dtype == 'EDA' \
-                    else None)
+                # Detect peaks in the window
+                seg_peaks, peak_label = self._detect_peaks(
+                    seg_data[signal_col],
+                    min_peak_amp = min_peak_amp if self.dtype == 'EDA' \
+                        else None)
 
-            # Add peak occurrence labels to full data
-            peak_indices = seg_data.index[seg_peaks]
+                # Add peak occurrence labels to full data
+                peak_indices = seg_data.index[seg_peaks]
+                preprocessed.loc[peak_indices, peak_label] = 1
+        else:
+            # Detect peaks in the entire signal
+            peaks_ix, peak_label = self._detect_peaks(
+                preprocessed[signal_col],
+                min_peak_amp = min_peak_amp if self.dtype == 'EDA' else None)
+            peak_indices = preprocessed.index[peaks_ix]
             preprocessed.loc[peak_indices, peak_label] = 1
 
         # Compute SQA metrics
@@ -316,7 +337,7 @@ class Preprocessor:
             event_data: pd.DataFrame
 
             # Preprocess the entire event
-            if self.seg_size is None:
+            if self.seg_size is None or self.peak_detection_mode == 'entire':
 
                 # Detect all peaks in the event
                 event_peaks, peak_label = self._detect_peaks(
@@ -329,7 +350,7 @@ class Preprocessor:
                 preprocessed.loc[peak_indices, peak_label] = 1
 
             # Preprocess each segment of the event
-            else:
+            elif self.seg_size or self.peak_detection_mode == 'segment':
 
                 # Segment each event
                 event_segments = self._segment_data(event_data)
@@ -534,6 +555,7 @@ class Preprocessor:
         data_resampled = pd.DataFrame()
         target_fs = resample_rate if resample_rate is not None \
             else (8 if self.fs > 8 else self.fs)
+        temp_rs = None
         if target_fs != self.fs:
             for col in signal_cols:
                 signal_rs = resample(data[col], self.fs, target_fs)
@@ -636,8 +658,7 @@ class Preprocessor:
         ts_col = 'Timestamp' if 'Timestamp' in data.columns else None
         has_event_times = self.event_times is not None \
                           and not self.event_times.empty
-        seg_size = (len(data) / self.fs) if \
-            (not self.seg_size and has_event_times) else self.seg_size
+        seg_size = self.seg_size if self.seg_size else (len(data) / self.fs)
 
         if self.dtype in ['ECG', 'PPG', 'BVP']:
             if not artifact_method or not artifact_tol:

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -374,6 +374,7 @@ def get_callbacks(app):
          Output('resampling-rate', 'disabled'),
          Output('load-temperature', 'hidden'),
          Output('temp-upload-section', 'hidden'),
+         Output('preprocess-data', 'hidden', allow_duplicate = True),
          Output('beat-detector-settings', 'hidden'),
          Output('artifact-settings', 'hidden'),
          Output('eda-preprocessing', 'hidden', allow_duplicate = True),
@@ -395,6 +396,7 @@ def get_callbacks(app):
         """Enable parameters specific to data types of CSV sources."""
         load_temp_hidden = True
         temp_upload_hidden = True
+        preprocess_data_hidden = True
         eda_preprocess_hidden = True
         beat_detector_settings_hidden = True
         artifact_settings_hidden = True
@@ -414,6 +416,7 @@ def get_callbacks(app):
             resample_hidden = False
             load_temp_hidden = False
             eda_preprocess_hidden = False
+            preprocess_data_hidden = False
             seg_size = 180
             if toggle_rs_on is True:
                 resample_disabled = False
@@ -432,6 +435,7 @@ def get_callbacks(app):
         if trig == 'e4-data-types' and e4_dtype == 'PPG':
             fs = 64
             eda_preprocess_hidden = True
+            preprocess_data_hidden = False
             beat_detector_settings_hidden = False
             artifact_settings_hidden = False
             beat_detectors = [
@@ -441,6 +445,7 @@ def get_callbacks(app):
         elif ctx.triggered_id == 'data-types' and dtype in ('PPG', 'ECG'):
             fs = 500
             eda_preprocess_hidden = True
+            preprocess_data_hidden = False
             beat_detector_settings_hidden = False
             artifact_settings_hidden = False
             if dtype == 'PPG':
@@ -457,7 +462,7 @@ def get_callbacks(app):
                 default_beat_detector = 'manikandan'
 
         return [fs, resample_hidden, resample_disabled,
-                load_temp_hidden, temp_upload_hidden,
+                load_temp_hidden, temp_upload_hidden, preprocess_data_hidden,
                 beat_detector_settings_hidden, artifact_settings_hidden,
                 eda_preprocess_hidden, scr_amp_thresh_hidden,
                 beat_detectors, default_beat_detector,
@@ -479,16 +484,29 @@ def get_callbacks(app):
 
     # === Set windowed/entire event segmentation ==============================
     @app.callback(
-        [Output('seg-size', 'disabled'),
+        [Output('peak-detection-mode', 'options'),
+         Output('seg-size', 'disabled'),
          Output('seg-size', 'value'),
          Output('segment-data-by-time', 'style')],
-        Input('event-segmentation-options', 'value')
+        [Input('event-segmentation-options', 'value'),
+         Input('seg-size', 'value'),
+         Input('toggle-event-segmentation', 'on')],
+        prevent_initial_call = True
     )
-    def disable_window_size(segment_event_by):
-        if segment_event_by == 'entire':
-            return True, None, {'color': '#bababa', 'fontStyle': 'italic'}
-        else:
-            return False, 60, {}
+    def handle_segmentation_params(segment_event_by, seg_size, toggle_on):
+        """Enable or disable the segment size input and 'By Segment' peak detection
+        option based on the event segmentation toggle state and selected segmentation
+        mode, greying out segment-related controls when entire-event processing is
+        active."""
+        disable = segment_event_by == 'entire' and toggle_on
+        segment_options = lambda disabled: [
+            {'label': 'Entire Signal', 'value': 'entire'},
+            {'label': 'By Segment', 'value': 'segment', 'disabled': disabled}
+        ]
+        if disable:
+            return segment_options(True), True, None, \
+                {'color': '#bababa', 'fontStyle': 'italic'}
+        return segment_options(False), False, seg_size or 60, {}
 
     # === Open advanced filter cutoff settings ================================
     @app.callback(
@@ -848,7 +866,7 @@ def get_callbacks(app):
     @app.callback(
         [Output('setup-data-header', 'hidden'),
          Output('setup-data', 'hidden'),
-         Output('preprocess-data', 'hidden'),
+         Output('preprocess-data', 'hidden', allow_duplicate = True),
          Output('eda-preprocessing', 'hidden', allow_duplicate = True),
          Output('segment-data', 'hidden'),
          Output('data-type-container', 'hidden'),     # data types div
@@ -895,7 +913,7 @@ def get_callbacks(app):
         # Default visibility
         hide_setup_header = False
         hide_setup = False
-        hide_preprocess = False
+        hide_preprocess = True
         hide_eda_preprocess = True
         hide_segment_data = False
         hide_data_types = False
@@ -933,6 +951,7 @@ def get_callbacks(app):
                 hide_setup = True
                 hide_data_types = True
                 hide_data_vars = True
+                hide_preprocess = False
                 dtype = 'ECG'
                 beat_detectors = [
                     {'label': 'Manikandan & Soman (2012)',
@@ -1225,6 +1244,7 @@ def get_callbacks(app):
             State('temperature-load', 'data'),
             State('temp-variable', 'value'),
             State('beat-detectors', 'value'),
+            State('peak-detection-mode', 'value'),
             State('seg-size', 'value'),
             State('artifact-method', 'value'),
             State('artifact-tol', 'value'),
@@ -1259,8 +1279,8 @@ def get_callbacks(app):
     )
     def run_pipeline(set_progress, n, load_data, e4_dtype, dtype, fs, rs,
                      d1, d2, d3, d4, d5, event_toggle_on, event_times,
-                     temp_data, temp_var, beat_detector, seg_size,
-                     artifact_method, artifact_tol, filt_on,
+                     temp_data, temp_var, beat_detector, beat_detection_mode,
+                     seg_size, artifact_method, artifact_tol, filter_on,
                      filter_lowcut, filter_highcut, filter_order,
                      filter_rp, filter_rs, filter_window_len, filter_len,
                      filter_window_type, scr_detector, min_peak_amp,
@@ -1372,7 +1392,8 @@ def get_callbacks(app):
 
                     # Initialize data preprocessing object for each file
                     preprocessor = _core.Preprocessor(
-                        dtype, fs, filt_on, peak_detector, event_df,
+                        dtype, fs, filter_on, peak_detector,
+                        beat_detection_mode, event_df,
                         seg_size, filter_kwargs)
 
                     # If timestamps are given
@@ -1534,8 +1555,8 @@ def get_callbacks(app):
 
                 # Initialize data preprocessing object
                 preprocessor = _core.Preprocessor(
-                    dtype, fs, filt_on, peak_detector, event_df, seg_size,
-                    filter_kwargs)
+                    dtype, fs, filter_on, peak_detector, beat_detection_mode,
+                    event_df, seg_size, filter_kwargs)
 
                 if file_type in ('Actiwave', 'E4'):
 
@@ -1590,8 +1611,8 @@ def get_callbacks(app):
 
                     # Reset preprocessor with device-specific sampling rates
                     preprocessor = _core.Preprocessor(
-                        dtype, fs, filt_on, peak_detector, event_df, seg_size,
-                        filter_kwargs)
+                        dtype, fs, filter_on, peak_detector, beat_detection_mode,
+                        event_df, seg_size, filter_kwargs)
 
                 # -- csv sources ---------------------------------------------
                 else:
@@ -1672,7 +1693,7 @@ def get_callbacks(app):
                     else:
                         try:
                             preprocessed, metrics = preprocessor.preprocess_full(
-                                data, dtype, artifact_method = artifact_method,
+                                data, artifact_method = artifact_method,
                                 artifact_tol = artifact_tol)
                         except Exception as e:
                             pipeline_error = True
@@ -1722,30 +1743,6 @@ def get_callbacks(app):
                         except RuntimeError:
                             pipeline_error = True
                             return _errors()
-                        try:
-                            preprocessed, preprocessed_by_event, \
-                                metrics_by_event = preprocessor.preprocess_event(
-                                data, rs, min_peak_amp, temp_data = temp,
-                                eda_min = eda_min, eda_max = eda_max)
-                        except Exception as e:
-                            pipeline_error = True
-                            print(traceback.format_exc())
-                            return dtype_error, map_error, pipeline_error, \
-                                event_file_error, temp_input_error, None
-
-                        for event_label, event_data in preprocessed_by_event.items():
-                            event_durations[event_label] = len(event_data) / preprocessor.fs
-                            event_data.to_csv(
-                                temp_path / f'{file}_{event_label}_EDA.csv',
-                                index = False)
-
-                            # Write downsampled event data to '_render' subdirectory
-                            _core.io._create_render(
-                                f'{file}_{event_label}', event_data, ds_acc = acc)
-
-                        # Write SQA metrics to 'temp' folder
-                        for event_label, metrics in metrics_by_event.items():
-                            metrics.to_csv(temp_path / f'{file}_{event_label}_SQA.csv', index = False)
 
                     # Segment-based EDA preprocessing
                     else:
@@ -1888,7 +1885,7 @@ def get_callbacks(app):
         prevent_initial_call = True
     )
     def create_beat_editor_files(all_subjects, selected_subject, all_events,
-                                 beat_correction_status, memory, filt_on,
+                                 beat_correction_status, memory, filter_on,
                                  prev_beats_edited):
         """Create Beat Editor _edit.json files for uploaded cardiac files and
         enable the 'Beat Editor' button."""
@@ -1910,7 +1907,7 @@ def get_callbacks(app):
             return btn_icon, 'no-spin', False
 
         fs = memory['fs']
-        signal_col = 'Filtered' if filt_on else data_type
+        signal_col = 'Filtered' if filter_on else data_type
 
         def _write_beat_editor_file(filename, batch):
             """Read CSV, downsample, and write a beat editor JSON file."""
@@ -2117,7 +2114,7 @@ def get_callbacks(app):
     )
     def update_sqa_table(memory, selected_subject, selected_event,
                          re_render_sqa_flag, all_subjects, all_events,
-                         segment_event_by, filt_on, seg_size):
+                         segment_event_by, filter_on, seg_size):
         """Update the SQA summary table and export batch options."""
         file = selected_subject
         event = selected_event
@@ -2150,7 +2147,7 @@ def get_callbacks(app):
         # Output signal quality table or EDA data
         else:
             eda = pd.read_csv(temp_path / f'{fstem}_EDA.csv')
-            signal_col = 'Filtered' if filt_on else 'EDA'
+            signal_col = 'Filtered' if filter_on else 'EDA'
             eda_signal = eda[signal_col].to_numpy()
             tonic_scl = compute_tonic_scl(eda_signal)
 
@@ -2228,7 +2225,7 @@ def get_callbacks(app):
                             accept_corrections_n, reject_corrections_n,
                             revert_corrections_n, beats_edited, all_subjects,
                             all_events, beat_correction_status, segment_size,
-                            filt_on, segments, artifact_method, artifact_tol,
+                            filter_on, segments, artifact_method, artifact_tol,
                             temp_data, eda_min):
         """Update the raw data plot based on the selected segment view."""
         if memory is None:
@@ -2243,7 +2240,7 @@ def get_callbacks(app):
             # Get render data for primary signal
             render_subdir = render_dir / file
             signal = pd.read_csv(str(render_subdir / 'signal.csv'))
-            y_axis_label = 'Filtered' if filt_on else data_type
+            y_axis_label = 'Filtered' if filter_on else data_type
             x_axis_label = 'Timestamp' if 'Timestamp' in signal.columns else \
                 'Sample'
             ts_col = 'Timestamp' if 'Timestamp' in signal.columns else None

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -378,6 +378,7 @@ def get_callbacks(app):
          Output('beat-detector-settings', 'hidden'),
          Output('artifact-settings', 'hidden'),
          Output('eda-preprocessing', 'hidden', allow_duplicate = True),
+         Output('select-scr-detector', 'hidden', allow_duplicate = True),
          Output('scr-amplitude-threshold', 'hidden'),
          Output('beat-detectors', 'options', allow_duplicate = True),
          Output('beat-detectors', 'value', allow_duplicate = True),
@@ -464,7 +465,9 @@ def get_callbacks(app):
         return [fs, resample_hidden, resample_disabled,
                 load_temp_hidden, temp_upload_hidden, preprocess_data_hidden,
                 beat_detector_settings_hidden, artifact_settings_hidden,
-                eda_preprocess_hidden, scr_amp_thresh_hidden,
+                eda_preprocess_hidden,   # eda-preprocessing
+                eda_preprocess_hidden,   # select-scr-detector
+                scr_amp_thresh_hidden,
                 beat_detectors, default_beat_detector,
                 scr_detectors, default_scr_detector, seg_size]
 
@@ -872,6 +875,7 @@ def get_callbacks(app):
          Output('setup-data', 'hidden'),
          Output('preprocess-data', 'hidden', allow_duplicate = True),
          Output('eda-preprocessing', 'hidden', allow_duplicate = True),
+         Output('select-scr-detector', 'hidden', allow_duplicate = True),
          Output('segment-data', 'hidden'),
          Output('data-type-container', 'hidden'),     # data types div
          Output('data-types', 'value'),
@@ -1084,7 +1088,9 @@ def get_callbacks(app):
 
         return (
             hide_setup_header, hide_setup, hide_preprocess,
-            hide_eda_preprocess,  hide_segment_data, hide_data_types, dtype,
+            hide_eda_preprocess,   # eda-preprocessing
+            hide_eda_preprocess,   # select-scr-detector
+            hide_segment_data, hide_data_types, dtype,
             hide_data_vars, hide_variable_error,
 
             # variable dropdowns

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -485,15 +485,18 @@ def get_callbacks(app):
     # === Set windowed/entire event segmentation ==============================
     @app.callback(
         [Output('peak-detection-mode', 'options'),
+         Output('peak-detection-mode', 'value'),
          Output('seg-size', 'disabled'),
          Output('seg-size', 'value'),
          Output('segment-data-by-time', 'style')],
         [Input('event-segmentation-options', 'value'),
          Input('seg-size', 'value'),
          Input('toggle-event-segmentation', 'on')],
+        [State('peak-detection-mode', 'value')],
         prevent_initial_call = True
     )
-    def handle_segmentation_params(segment_event_by, seg_size, toggle_on):
+    def handle_segmentation_params(segment_event_by, seg_size, toggle_on,
+                                   current_mode):
         """Enable or disable the segment size input and 'By Segment' peak detection
         option based on the event segmentation toggle state and selected segmentation
         mode, greying out segment-related controls when entire-event processing is
@@ -504,9 +507,10 @@ def get_callbacks(app):
             {'label': 'By Segment', 'value': 'segment', 'disabled': disabled}
         ]
         if disable:
-            return segment_options(True), True, None, \
+            return segment_options(True), 'entire', True, None, \
                 {'color': '#bababa', 'fontStyle': 'italic'}
-        return segment_options(False), False, seg_size or 60, {}
+        return segment_options(False), current_mode or 'entire', False, \
+            seg_size or 60, {}
 
     # === Open advanced filter cutoff settings ================================
     @app.callback(

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -248,34 +248,31 @@ layout = html.Div(id = 'main', children = [
                 html.Div(id = 'select-beat-detector', children = [
                     html.Span('Beat Detector:'),
                     dcc.Dropdown(id = 'beat-detectors',
-                                 options = [], clearable = False),
-                    html.Div(
-                        style = {'display': 'flex', 'alignItems': 'center',
-                                 'gap': '14px', 'flexWrap': 'nowrap', 'marginTop': '5px'},
-                        children = [
-                            html.Span('Detection Mode:'),
-                            html.I(className = 'fa-regular fa-circle-question',
-                                   id = 'detection-mode-help'),
-                            dbc.Tooltip(
-                                'Choose whether to detect peaks across the entire signal '
-                                'or segment by segment. The segment length is set '
-                                'by the \'window size\' field.',
-                                target = 'detection-mode-help'),
-                            dbc.RadioItems(
-                                id = 'peak-detection-mode',
-                                options = [
-                                    {'label': 'Entire Signal', 'value': 'entire'},
-                                    {'label': 'By Segment', 'value': 'segment', 'disabled': False}
-                                ], value = 'entire', inline = True)
-                        ])
+                                 options = [], clearable = False)
                 ])
             ]),
+            html.Div(id = 'select-scr-detector', hidden = True, children = [
+                html.Span('SCR Detector:'),
+                dcc.Dropdown(id = 'scr-detectors',
+                             options = [], clearable = False)
+            ]),
+            html.Div(id = 'peak-detection-mode-div', children = [
+                html.Span('Detection Mode:'),
+                html.I(className = 'fa-regular fa-circle-question',
+                       id = 'detection-mode-help'),
+                dbc.Tooltip(
+                    'Choose whether to detect peaks across the entire signal '
+                    'or segment by segment. The segment length is set '
+                    'by the \'window size\' field.',
+                    target = 'detection-mode-help'),
+                dbc.RadioItems(
+                    id = 'peak-detection-mode',
+                    options = [
+                        {'label': 'Entire Signal', 'value': 'entire'},
+                        {'label': 'By Segment', 'value': 'segment', 'disabled': False}
+                    ], value = 'entire', inline = True)
+            ]),
             html.Div(id = 'eda-preprocessing', hidden = True, children = [
-                html.Div(id = 'select-scr-detector', children = [
-                    html.Span('SCR Detector:'),
-                    dcc.Dropdown(id = 'scr-detectors',
-                                 options = [], clearable = False)
-                ]),
                 html.Div(id = 'scr-amplitude-threshold', children = [
                     html.Span('Minimum Peak Amplitude (µS):'),
                     dcc.Input(id = 'scr-amp-thresh', value = None, type = 'number'),

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -195,7 +195,7 @@ layout = html.Div(id = 'main', children = [
             ]),
             html.Div(id = 'segment-data-by-time', children = [
                 html.Span('Window Size (sec):'),
-                dcc.Input(id = 'seg-size', type = 'number'),
+                dcc.Input(id = 'seg-size', type = 'number', min = 5, value = 60),
                 html.I(className = 'fa-regular fa-circle-question',
                        id = 'seg-data-help'),
                 dbc.Tooltip(
@@ -248,7 +248,26 @@ layout = html.Div(id = 'main', children = [
                 html.Div(id = 'select-beat-detector', children = [
                     html.Span('Beat Detector:'),
                     dcc.Dropdown(id = 'beat-detectors',
-                                 options = [], clearable = False)
+                                 options = [], clearable = False),
+                    html.Div(
+                        style = {'display': 'flex', 'alignItems': 'center',
+                                 'gap': '14px', 'flexWrap': 'nowrap', 'marginTop': '5px'},
+                        children = [
+                            html.Span('Detection Mode:'),
+                            html.I(className = 'fa-regular fa-circle-question',
+                                   id = 'detection-mode-help'),
+                            dbc.Tooltip(
+                                'Choose whether to detect peaks across the entire signal '
+                                'or segment by segment. The segment length is set '
+                                'by the \'window size\' field.',
+                                target = 'detection-mode-help'),
+                            dbc.RadioItems(
+                                id = 'peak-detection-mode',
+                                options = [
+                                    {'label': 'Entire Signal', 'value': 'entire'},
+                                    {'label': 'By Segment', 'value': 'segment', 'disabled': False}
+                                ], value = 'entire', inline = True)
+                        ])
                 ])
             ]),
             html.Div(id = 'eda-preprocessing', hidden = True, children = [
@@ -259,12 +278,11 @@ layout = html.Div(id = 'main', children = [
                 ]),
                 html.Div(id = 'scr-amplitude-threshold', children = [
                     html.Span('Minimum Peak Amplitude (µS):'),
-                    dcc.Input(id = 'scr-amp-thresh', value = None, type =
-                    'number'),
+                    dcc.Input(id = 'scr-amp-thresh', value = None, type = 'number'),
                     html.I(className = 'fa-regular fa-circle-question',
-                       id = 'min-peak-amp-help'),
+                           id = 'min-peak-amp-help'),
                     dbc.Tooltip(
-                        'Exclude SCR peaks with ampitudes below this '
+                        'Exclude SCR peaks with amplitudes below this '
                         'threshold. If this field is empty, no amplitude '
                         'threshold is used.',
                         target = 'min-peak-amp-help')


### PR DESCRIPTION
### Link to Issue
* Resolves https://github.com/cbslneu/physioview/issues/74

### Summary
Previously, the PhysioView Dashboard supported only segment-by-segment peak detection. This PR adds UI elements and callback functions to **allow users to select whether peak detection should be applied to the entire signal or on a segment-by-segment basis**. The size of the segment is controlled by the inputted value to the `dcc.Input(id = 'seg-size')` component. A minimum value of 5 seconds has also been set for the window size.

Additionally, the `'seg-size'` input field and the "By Segment" detection mode option are disabled when entire-event processing is active (i.e., `daq.BooleanSwitch(id = 'toggle-event-segmentation')` is switched on and the segmentation mode is set to "Entire"). When disabled, the segment size value is cleared to prevent it from being passed to `Preprocessor` in the `dashboard._core.preprocessing` module. If the field is cleared while it's enabled, the value defaults to 60 seconds to prevent an empty input.