### PR TITLE
BE-18: Disable left click for Mark Unusable mode

### DIFF
--- a/beat-editor/frontend/utils/CreateChartOptions.ts
+++ b/beat-editor/frontend/utils/CreateChartOptions.ts
@@ -47,7 +47,7 @@ const createChartOptions = ({
         type: isMarkingUnusableMode ? undefined : "x",
       },
       panning: {
-        enabled: true, // Disable panning in Mark Unusable mode
+        enabled: !isMarkingUnusableMode, // Disable panning in Mark Unusable mode
       },
       panKey: "shift",
       events: {
@@ -147,7 +147,7 @@ const createChartOptions = ({
         point: {
           events: {
             click: function (event) {
-              if (isAddMode || isDeleteMode || isMarkingUnusableMode) {
+              if (isAddMode || isDeleteMode) {
                 const chartClickEvent: ChartClickEvent = {
                   point: { x: this.x, y: this.y as number },
                   xAxis: [{ value: this.x }],


### PR DESCRIPTION
## Link to Issue(s)
- Closes: https://github.com/cbslneu/physioview/issues/65

## Summary
- Disabling left click when user is in `Mark Unusable` mode
- What changed:
  - `Mark Unusable` is right click only
- How to test:
  1. Click on `Mark Unusable`
  2. Try to drag left and right

## Screenshots

https://github.com/user-attachments/assets/98260c84-b610-4d32-bbc4-838a78fb3f68

