### PR TITLE
[BE-19] Add feature for validating potential artifacts as beats

### DIFF
--- a/assets/beat_editor_focus.js
+++ b/assets/beat_editor_focus.js
@@ -1,0 +1,43 @@
+// Auto-focus the Beat Editor iframe when its modal opens, so the editor's
+// keyboard shortcuts work immediately without the user clicking inside it
+window.dash_clientside = window.dash_clientside || {};
+window.dash_clientside.clientside = window.dash_clientside.clientside || {};
+
+window.dash_clientside.clientside.focusBeatEditor = function (is_open) {
+    if (!is_open) {
+        return window.dash_clientside.no_update;
+    }
+
+    // Move focus into the iframe (and its content window) once its content
+    // has loaded, so keystrokes route to the Beat Editor's own window where
+    // the shortcut listener lives
+    const focusEditor = function () {
+        const ifr = document.getElementById('beat-editor-iframe');
+        if (!ifr) {
+            return false;
+        }
+        const grab = function () {
+            try { ifr.contentWindow.focus(); } catch (e) {}
+            ifr.focus();
+        };
+        ifr.addEventListener('load', function () {
+            setTimeout(grab, 100);
+        }, { once: true });
+        setTimeout(grab, 300);  // fallback if the iframe already loaded
+        return true;
+    };
+
+    // The iframe is usually already present when the modal opens, so focus it
+    // now; otherwise wait for it (MutationObserver only sees future changes)
+    if (!focusEditor()) {
+        const observer = new MutationObserver(function (_mutations, obs) {
+            if (focusEditor()) {
+                obs.disconnect();
+            }
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        setTimeout(function () { observer.disconnect(); }, 5000);
+    }
+
+    return window.dash_clientside.no_update;
+};

--- a/beat-editor/frontend/components/BeatChart/BeatChart.tsx
+++ b/beat-editor/frontend/components/BeatChart/BeatChart.tsx
@@ -11,6 +11,7 @@ import {
   EDIT_TYPE_ADD,
   EDIT_TYPE_DELETE,
   EDIT_TYPE_UNUSABLE,
+  EDIT_TYPE_VALID,
 } from "../../constants/constants";
 import KeyboardShortcuts from "../KeyboardShortcuts/KeyboardShortcuts";
 import useMarkingUnusableMode from "../../hooks/useMarkingUnusableMode";
@@ -26,6 +27,7 @@ import SaveButton from "../SaveButton/SaveButton";
 import ExportButton from "../ExportButton/ExportButton";
 import ImportEditsButton from "../ImportEditsButton/ImportEditsButton";
 import LabelToggle from "../LabelToggle/LabelToggle";
+import ToolbarDivider from "../ToolbarDivider/ToolbarDivider";
 
 Highcharts.SVGRenderer.prototype.symbols.cross = function (
   x: number,
@@ -81,6 +83,7 @@ const BeatChart = ({
   const [isPanning, setIsPanning] = useState(false);
   const [isMarkingUnusableMode, setIsMarkingUnusableMode] = useState(false);
   const [isRemoveEditMode, setIsRemoveEditMode] = useState(false);
+  const [isMarkValidMode, setIsMarkValidMode] = useState(false);
   const [isLabelOn, setIsLabelOn] = useState(true);
   const [allUserEdits, setAllUserEdits] = useState<(SavedBeat | SegmentObj)[]>(
     [],
@@ -157,6 +160,7 @@ const BeatChart = ({
       isAddMode,
       isDeleteMode,
       isMarkingUnusableMode,
+      isMarkValidMode,
       isRemoveEditMode,
       isLabelOn,
       handleChartClick,
@@ -176,6 +180,7 @@ const BeatChart = ({
     isRemoveEditMode,
     selectedSegment,
     isMarkingUnusableMode,
+    isMarkValidMode,
     isLabelOn,
   ]);
 
@@ -229,6 +234,10 @@ const BeatChart = ({
     ) {
       return;
     }
+    // In Mark Valid mode, ignore clicks on non-artifact points while panning
+    if (isPanning && isMarkValidMode && !isArtifactCoordinate) {
+      return;
+    }
 
     const updatedCardiacData = [...cardiacData, { x: newX, y: newY }];
     const updatedBeatData = [...beatData];
@@ -237,6 +246,11 @@ const BeatChart = ({
     setAllUserEdits((prev) => {
       if (isDeleteMode && !(isBeatCoordinate || isArtifactCoordinate)) {
         toast.error("This is not a beat");
+        return prev;
+      }
+
+      if (isMarkValidMode && !isArtifactCoordinate) {
+        toast.error("This is not an artifactual beat");
         return prev;
       }
 
@@ -258,6 +272,16 @@ const BeatChart = ({
             y: newY,
             segment: selectedSegment,
             editType: EDIT_TYPE_ADD,
+          },
+        ];
+      } else if (isMarkValidMode) {
+        return [
+          ...prev,
+          {
+            x: newX,
+            y: newY,
+            segment: selectedSegment,
+            editType: EDIT_TYPE_VALID,
           },
         ];
       } else if (isRemoveEditMode) {
@@ -322,6 +346,7 @@ const BeatChart = ({
     setIsDeleteMode(false);
     setIsMarkingUnusableMode(false);
     setIsRemoveEditMode(false);
+    setIsMarkValidMode(false);
   };
 
   const toggleDeleteMode = () => {
@@ -330,6 +355,7 @@ const BeatChart = ({
     setIsDeleteMode((prev) => !prev);
     setIsMarkingUnusableMode(false);
     setIsRemoveEditMode(false);
+    setIsMarkValidMode(false);
   };
 
   const toggleMarkUnusableMode = () => {
@@ -338,6 +364,16 @@ const BeatChart = ({
     setIsAddMode(false);
     setIsDeleteMode(false);
     setIsRemoveEditMode(false);
+    setIsMarkValidMode(false);
+  };
+
+  const toggleMarkValidMode = () => {
+    resetInteractionState();
+    setIsAddMode(false);
+    setIsDeleteMode(false);
+    setIsMarkingUnusableMode(false);
+    setIsRemoveEditMode(false);
+    setIsMarkValidMode((prev) => !prev);
   };
 
   const toggleRemoveEditMode = () => {
@@ -345,6 +381,7 @@ const BeatChart = ({
     setIsAddMode(false);
     setIsDeleteMode(false);
     setIsMarkingUnusableMode(false);
+    setIsMarkValidMode(false);
     setIsRemoveEditMode((prev) => !prev);
   };
 
@@ -360,6 +397,7 @@ const BeatChart = ({
     toggleAddMode,
     toggleDeleteMode,
     toggleMarkUnusableMode,
+    toggleMarkValidMode,
     toggleRemoveEditMode,
   });
 
@@ -399,9 +437,16 @@ const BeatChart = ({
         onClick: toggleMarkUnusableMode,
       },
       {
+        id: "mark-valid",
+        icon: "fa-solid fa-check",
+        label: "Mark Valid Beat",
+        className: isMarkValidMode ? "mark-valid-active" : "",
+        onClick: toggleMarkValidMode,
+      },
+      {
         id: "remove-edit",
         icon: "fa-solid fa-times",
-        label: "Remove",
+        label: "Remove Edit",
         className: isRemoveEditMode ? "remove-edit-active" : "",
         onClick: toggleRemoveEditMode,
       },
@@ -410,10 +455,12 @@ const BeatChart = ({
       isAddMode,
       isDeleteMode,
       isMarkingUnusableMode,
+      isMarkValidMode,
       isRemoveEditMode,
       toggleAddMode,
       toggleDeleteMode,
       toggleMarkUnusableMode,
+      toggleMarkValidMode,
       toggleRemoveEditMode,
     ],
   );
@@ -423,7 +470,7 @@ const BeatChart = ({
       <div className="flex w-full mb-4 justify-between items-center">
         <div className="flex flex-wrap gap-2 mb-5 items-center">
           <select
-            className="p-0 w-[50px] h-[40px] text-center text-[16px] border border-[#3d4951] rounded-md focus:outline-none"
+            className="p-0 w-[50px] h-[36px] text-center text-[16px] border border-[#3d4951] rounded-md focus:outline-none"
             value={selectedSegment}
             onChange={(e) => {
               setSelectedSegment(e.target.value);
@@ -449,6 +496,9 @@ const BeatChart = ({
             ))}
           </select>
 
+          {/* Divider separating segment navigation from editing tools */}
+          <ToolbarDivider />
+
           {Object.values(buttonObjParams).map((param) => {
             return (
               <button
@@ -461,6 +511,9 @@ const BeatChart = ({
               </button>
             );
           })}
+
+          {/* Divider separating editing tools from file actions */}
+          <ToolbarDivider />
 
           <SaveButton fileName={fileName} allEdits={allUserEdits} />
           <ImportEditsButton onImportSuccess={onRefresh} />

--- a/beat-editor/frontend/components/ImportEditsButton/ImportEditsButton.tsx
+++ b/beat-editor/frontend/components/ImportEditsButton/ImportEditsButton.tsx
@@ -53,7 +53,7 @@ const ImportEditsButton = ({ onImportSuccess }: ImportEditsButtonProps) => {
 
   return (
     <button className="import-button" onClick={handleImport}>
-      <i className="fa-solid fa-file-import"></i>Import Edits
+      <i className="fa-solid fa-file-import"></i>Import
     </button>
   );
 };

--- a/beat-editor/frontend/components/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/beat-editor/frontend/components/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -79,7 +79,7 @@ const KeyboardShortcuts = () => {
       </div>
       {showKeyboardShortcut && (
         <div
-          className="absolute w-[380px] shadow-[0_4px_12px_rgba(0,0,0,0.15)] p-4 top-[calc(100%+15px)] left-[-140px] transform -translate-x-1/2 border border-[#47555e] rounded-lg bg-white z-[1000] text-[#47555e]"
+          className="absolute w-[420px] shadow-[0_4px_12px_rgba(0,0,0,0.15)] p-4 top-[calc(100%+15px)] left-[-160px] transform -translate-x-1/2 border border-[#47555e] rounded-lg bg-white z-[1000] text-[#47555e]"
           ref={keyboardShortcutsRef}
         >
           <div className="absolute right-[5px] top-[-11px] z-[1] h-0 w-0 -translate-x-1/2 border-x-[10px] border-x-transparent border-b-[10px] border-b-[#47555e] after:content-[''] after:absolute after:left-[-10px] after:top-[2px] after:h-0 after:w-0 after:border-x-[10px] after:border-x-transparent after:border-b-[10px] after:border-b-white" />
@@ -87,7 +87,7 @@ const KeyboardShortcuts = () => {
             Keyboard Shortcuts
           </h2>
 
-          <div className="grid grid-cols-3 gap-4 mb-4">
+          <div className="grid grid-cols-4 gap-4 mb-4">
             {TOP_ROW_SHORTCUTS.map((shortcut) => {
               const { icon, label } = shortcut;
               return (

--- a/beat-editor/frontend/components/KeyboardShortcuts/constants.ts
+++ b/beat-editor/frontend/components/KeyboardShortcuts/constants.ts
@@ -16,8 +16,12 @@ export const TOP_ROW_SHORTCUTS = [
     label: "Delete Beat",
   },
   {
+    icon: "fa-solid fa-v keybind",
+    label: "Mark Valid Beat",
+  },
+  {
     icon: "fa-solid fa-r keybind",
-    label: "Remove",
+    label: "Remove Edit",
   },
 ];
 

--- a/beat-editor/frontend/components/ToolbarDivider/ToolbarDivider.tsx
+++ b/beat-editor/frontend/components/ToolbarDivider/ToolbarDivider.tsx
@@ -1,0 +1,10 @@
+const ToolbarDivider = () => {
+  return (
+    <div
+      className="w-px h-[34px] bg-[#bbbbbb] self-center mx-1"
+      aria-hidden="true"
+    />
+  );
+};
+
+export default ToolbarDivider;

--- a/beat-editor/frontend/constants/constants.ts
+++ b/beat-editor/frontend/constants/constants.ts
@@ -5,3 +5,4 @@
 export const EDIT_TYPE_ADD = "ADD";
 export const EDIT_TYPE_DELETE = "DELETE";
 export const EDIT_TYPE_UNUSABLE = "UNUSABLE";
+export const EDIT_TYPE_VALID = "VALID";

--- a/beat-editor/frontend/styles.css
+++ b/beat-editor/frontend/styles.css
@@ -38,14 +38,17 @@ button {
   text-transform: uppercase;
   font-family: 'Poppins', sans-serif !important;
   font-weight: bold;
-  font-size: 14px;
+  font-size: 12px;
   letter-spacing: 2px;
-  border: 2px solid transparent !important;
+  border: 0px solid transparent !important;
   color: #ffffff;
   text-align: center;
   border-radius: 4px;
   padding: 8px;
+  height: 36px;
+  box-sizing: border-box;
   display: flex;
+  align-items: center;
   cursor: pointer;
 }
 
@@ -54,13 +57,13 @@ button:hover {
 }
 
 button i {
-    margin-top: 3px;
     margin-right: 3px;
 }
 
 .add-beat-active,
 .delete-beat-active,
 .mark-unusable-active,
+.mark-valid-active,
 .remove-edit-active {
   background-color: #ee8a78;
 }
@@ -73,6 +76,12 @@ button i {
 .Toastify__toast,
 .Toastify__toast-body {
   font-family: 'Poppins', sans-serif !important;
+  font-size: 14px;
+}
+
+.Toastify__close-button,
+.Toastify__close-button:hover {
+  background-color: transparent !important;
 }
 
 .keybind {
@@ -81,7 +90,6 @@ button i {
   padding: 5px;
   padding-left: 8px;
   padding-right: 8px;
-  margin-right: 5px;
 }
 
 .rt-click-keybind {
@@ -111,6 +119,7 @@ button i {
   font-size: 12px;
   text-align: center;
   font-weight: 500;
+  white-space: nowrap;
 }
 
 .mark-unusable-option {

--- a/beat-editor/frontend/types/types.ts
+++ b/beat-editor/frontend/types/types.ts
@@ -50,6 +50,7 @@ export interface ChartOptions {
   isAddMode: boolean;
   isDeleteMode: boolean;
   isMarkingUnusableMode: boolean;
+  isMarkValidMode: boolean;
   isRemoveEditMode: boolean;
   isLabelOn: boolean;
   removeEdit: (edit: SavedBeat) => void;

--- a/beat-editor/frontend/utils/CreateChartOptions.ts
+++ b/beat-editor/frontend/utils/CreateChartOptions.ts
@@ -2,6 +2,7 @@ import {
   EDIT_TYPE_ADD,
   EDIT_TYPE_DELETE,
   EDIT_TYPE_UNUSABLE,
+  EDIT_TYPE_VALID,
 } from "../constants/constants";
 import {
   ChartClickEvent,
@@ -20,6 +21,7 @@ const createChartOptions = ({
   isAddMode,
   isDeleteMode,
   isMarkingUnusableMode,
+  isMarkValidMode,
   isRemoveEditMode,
   isLabelOn,
   removeEdit,
@@ -34,6 +36,9 @@ const createChartOptions = ({
   );
   const unusableSegments: SegmentObj[] = allUserEdits.filter(
     (edit): edit is SegmentObj => edit.editType === EDIT_TYPE_UNUSABLE,
+  );
+  const validModeCoordinates: SavedBeat[] = allUserEdits.filter(
+    (edit) => edit.editType === EDIT_TYPE_VALID,
   );
 
   return {
@@ -115,6 +120,11 @@ const createChartOptions = ({
       title: {
         text: "Signal",
       },
+      labels: {
+        style: {
+          fontSize: "0.7em",
+        },
+      },
       allowDecimals: true,
     },
     tooltip: {
@@ -149,7 +159,7 @@ const createChartOptions = ({
         point: {
           events: {
             click: function (event) {
-              if (isAddMode || isDeleteMode) {
+              if (isAddMode || isDeleteMode || isMarkValidMode) {
                 const chartClickEvent: ChartClickEvent = {
                   point: { x: this.x, y: this.y as number },
                   xAxis: [{ value: this.x }],
@@ -182,7 +192,7 @@ const createChartOptions = ({
         point: {
           events: {
             click: function (event) {
-              if (isAddMode || isDeleteMode) {
+              if (isAddMode || isDeleteMode || isMarkValidMode) {
                 const chartClickEvent: ChartClickEvent = {
                   point: { x: this.x, y: this.y as number },
                   xAxis: [{ value: this.x }],
@@ -196,7 +206,7 @@ const createChartOptions = ({
         },
       },
       {
-        name: "Artifact",
+        name: "Potential Artifact",
         data: initArtifacts,
         type: "scatter",
         color: "red",
@@ -217,7 +227,7 @@ const createChartOptions = ({
         point: {
           events: {
             click: function (event) {
-              if (isAddMode || isDeleteMode) {
+              if (isAddMode || isDeleteMode || isMarkValidMode) {
                 const chartClickEvent: ChartClickEvent = {
                   point: { x: this.x, y: this.y as number },
                   xAxis: [{ value: this.x }],
@@ -311,6 +321,54 @@ const createChartOptions = ({
                   y: this.y as number,
                   segment: selectedSegment,
                   editType: EDIT_TYPE_DELETE,
+                };
+                handleChartClick(clickedEdit);
+                return;
+              }
+
+              const chartClickEvent: ChartClickEvent = {
+                point: { x: this.x, y: this.y as number },
+                xAxis: [{ value: this.x }],
+                yAxis: [{ value: this.y as number }],
+                target: event.target,
+              };
+              handleChartClick(chartClickEvent);
+            },
+          },
+        },
+      },
+      {
+        name: "Validated Beat",
+        data: validModeCoordinates.filter((o) => o.segment === selectedSegment),
+        type: "scatter",
+        color: "#F9C669",
+        marker: {
+          symbol: "circle",
+          lineColor: "#02E337",
+          lineWidth: 2,
+        },
+        visible: validModeCoordinates.some((o) => o.segment === selectedSegment),
+        showInLegend: validModeCoordinates.some(
+          (o) => o.segment === selectedSegment,
+        ),
+        turboThreshold: 0,
+        states: {
+          hover: {
+            enabled: false,
+          },
+          inactive: {
+            enabled: false,
+          },
+        },
+        point: {
+          events: {
+            click: function (event) {
+              if (isRemoveEditMode) {
+                const clickedEdit: SavedBeat = {
+                  x: this.x,
+                  y: this.y as number,
+                  segment: selectedSegment,
+                  editType: EDIT_TYPE_VALID,
                 };
                 handleChartClick(clickedEdit);
                 return;

--- a/beat-editor/frontend/utils/key-input-utils.ts
+++ b/beat-editor/frontend/utils/key-input-utils.ts
@@ -4,6 +4,7 @@ interface useKeyboardShortcutsProps {
   toggleAddMode: () => void;
   toggleDeleteMode: () => void;
   toggleMarkUnusableMode: () => void;
+  toggleMarkValidMode: () => void;
   toggleRemoveEditMode: () => void;
 }
 
@@ -11,6 +12,7 @@ const useKeyboardShortcuts = ({
   toggleAddMode,
   toggleDeleteMode,
   toggleMarkUnusableMode,
+  toggleMarkValidMode,
   toggleRemoveEditMode,
 }: useKeyboardShortcutsProps) => {
   const handleKeyDown = (event: KeyboardEvent) => {
@@ -20,6 +22,8 @@ const useKeyboardShortcuts = ({
       toggleDeleteMode();
     } else if (event.key === "U" || event.key === "u") {
       toggleMarkUnusableMode();
+    } else if (event.key === "V" || event.key === "v") {
+      toggleMarkValidMode();
     } else if (event.key === "R" || event.key === "r") {
       toggleRemoveEditMode();
     }

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -1822,21 +1822,21 @@ def get_callbacks(app):
                       selected_subject, selected_event, segment_size):
         """Recompute signal quality metrics after beat corrections or edits."""
         trig = ctx.triggered_id
+        file = f'{selected_subject}_{selected_event}' if selected_event \
+            else selected_subject
         if trig == 'beat-correction-status':
-            if selected_subject not in beat_correction_status.keys():
+            if file not in beat_correction_status.keys():
                 return False
-            elif beat_correction_status[selected_subject] == 'suggested':
+            elif beat_correction_status[file] == 'suggested':
                 return False
         elif trig == 'be-edited-trigger':
-            if beats_edited != selected_subject:
+            if beats_edited != file:
                 return False
 
         fs = memory['fs']
         data_type = memory['data type']
         beat_editor_fs = memory['downsampled fs']
         sqa = SQA.Cardio(fs)
-        file = f'{selected_subject}_{selected_event}' if selected_event \
-            else selected_subject
 
         preprocessed_data = pd.read_csv(
             temp_path / f'{file}_{data_type}.csv')
@@ -2406,6 +2406,14 @@ def get_callbacks(app):
                     artifacts_edited = sqa.identify_artifacts(
                         data_edited_beats_ix, method = artifact_method,
                         tol = artifact_tol)
+
+                    # Exclude beats marked as valid from recomputed artifacts
+                    if 'Validated Beat' in data_edited.columns:
+                        valid_beats_ix = data_edited[
+                            data_edited['Validated Beat'] == 1].index.values
+                        artifacts_edited = np.setdiff1d(
+                            artifacts_edited, valid_beats_ix)
+
                     if 'Artifact' in data_edited.columns:
                         artifact_col_pos = data_edited.columns.get_loc('Artifact')
                         del data_edited['Artifact']
@@ -3274,7 +3282,8 @@ def get_callbacks(app):
                                     inplace = True)
                         beats_col = 'Original Beat'
                     col_order = ['Segment', ts_col, data_type, 'Filtered',
-                                 beats_col, 'Artifact', 'Auto Corrected Beat',
+                                 beats_col, 'Original Artifact', 'Artifact',
+                                 'Auto Corrected Beat',
                                  'Deleted Beat',  'Added Beat',
                                  'Unusable', 'Edited Beat']
                     order = [c for c in col_order if c in data.columns]
@@ -3301,7 +3310,8 @@ def get_callbacks(app):
                             else:
                                 beats_col = 'Beat'
                             col_order = ['Segment', ts_col, data_type,
-                                         'Filtered', beats_col, 'Artifact',
+                                         'Filtered', beats_col,
+                                         'Original Artifact', 'Artifact',
                                          'Auto Corrected Beat', 'Edited Beat']
                             order = [c for c in col_order if c in data.columns]
                             data = data[order]

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -2886,7 +2886,8 @@ def get_callbacks(app):
     @app.callback(
         [Output('beat-editor-modal', 'is_open'),
          Output('beat-editor-content', 'children'),
-         Output('ok-beat-edits', 'disabled')],
+         Output('ok-beat-edits', 'disabled'),
+         Output('beat-editor-editing-label', 'children')],
         [Input('open-beat-editor', 'n_clicks'),
          Input('ok-beat-edits', 'n_clicks'),
          Input('cancel-beat-edits', 'n_clicks'),
@@ -2901,7 +2902,15 @@ def get_callbacks(app):
         clicked = ctx.triggered_id
 
         if clicked in ('cancel-beat-edits', 'ok-beat-edits'):
-            return False, None, False
+            return False, None, False, ''
+
+        # Label indicating which subject (and event, if any) is being edited
+        if selected_subject and selected_event:
+            editing_label = f'Editing: {selected_subject} — {selected_event}'
+        elif selected_subject:
+            editing_label = f'Editing: {selected_subject}'
+        else:
+            editing_label = ''
 
         data_dir = Path('beat-editor/data')
         batch_dir = data_dir / 'batch'
@@ -2973,7 +2982,7 @@ def get_callbacks(app):
         except:
             content = html.Span('No data available.')
             apply_disabled = True
-        return True, content, apply_disabled
+        return True, content, apply_disabled, editing_label
 
     # ======================= POSTPROCESESING MODAL ==========================
     # === Open/Close Postprocessing modal ====================================

--- a/physioview/dashboard/callbacks.py
+++ b/physioview/dashboard/callbacks.py
@@ -1,6 +1,6 @@
 from . import _core
 from typing import Literal, Optional, Tuple
-from dash import html, Input, Output, State, ctx, callback, no_update
+from dash import html, Input, Output, State, ctx, callback, no_update, ClientsideFunction
 from dash.exceptions import PreventUpdate
 from dash.dcc import send_bytes
 from physioview import physioview
@@ -3463,20 +3463,8 @@ def get_callbacks(app):
 
     # ========= Clientside callback to auto-focus Beat Editor iFrame =========
     app.clientside_callback(
-        """
-        function(is_open) {
-            const KEY = "__beat_editor_focus_observer";
-            const observer = new MutationObserver((_mutations, obs) => {
-                const ifr = document.getElementById('beat-editor-iframe');
-                ifr.focus();
-                obs.disconnect();
-            });
-            
-            observer.observe(document.body, { childList: true, subtree: true });
-            
-            return window.dash_clientside.no_update;
-        }
-        """,
+        ClientsideFunction(
+            namespace = 'clientside', function_name = 'focusBeatEditor'),
         Output('beat-editor-iframe-listener', 'data'),
         Input('beat-editor-modal', 'is_open'),
         prevent_initial_call = True

--- a/physioview/dashboard/layout.py
+++ b/physioview/dashboard/layout.py
@@ -847,7 +847,12 @@ layout = html.Div(id = 'main', children = [
                     html.Div(id = 'beat-editor-content', children = [])
                 ])
             ]),
-            dbc.ModalFooter(children = [
+            dbc.ModalFooter(style = {'justifyContent': 'space-between'},
+                            children = [
+                html.Div(id = 'beat-editor-editing-label',
+                         style = {'fontStyle': 'italic', 'fontSize': '12px',
+                                  'color': '#6c757d', 'textAlign': 'left',
+                                  'alignSelf': 'center'}),
                 html.Div(id = 'beat-editor-buttons', children = [
                     html.Button('Cancel', id = 'cancel-beat-edits'),
                     html.Button('Apply Edits', id = 'ok-beat-edits'),

--- a/physioview/physioview.py
+++ b/physioview/physioview.py
@@ -1724,7 +1724,7 @@ def process_beat_edits(
         A DataFrame of edit instructions parsed from a Beat Editor
         `_edited.json` file.  Must contain:
 
-        - 'editType': one of 'ADD', 'DELETE', or 'UNUSABLE'
+        - 'editType': one of 'ADD', 'DELETE', 'UNUSABLE', or 'VALID'
         - either 'x' (edit location) or 'from' (start of unusable segment,
           with 'to' as the end), in the same time or sample units as
           `orig_data`
@@ -1738,6 +1738,12 @@ def process_beat_edits(
         - 'Deleted Beat': 1 where beats were deleted, otherwise `NaN`
         - 'Added Beat': 1 where beats were added, otherwise `NaN`
         - 'Unusable': 1 where segments are marked unusable, otherwise `NaN`
+        - 'Validated Beat': 1 where artifactual beats were manually marked as
+          valid, otherwise `NaN`. These beats are excluded from artifact
+          flagging when the artifact identification algorithm is re-run.
+        - 'Original Artifact': 1 where beats were originally flagged as
+          potential artifacts, otherwise `NaN`. Only added when beats have
+          been validated, preserving the pre-validation artifact flags.
     """
 
     # Validate edits input
@@ -1839,11 +1845,16 @@ def process_beat_edits(
     # Record final edited beat occurrences
     deletions_ix = processed[processed['editType'] == 'DELETE'].index.values
     additions_ix = processed[processed['editType'] == 'ADD'].index.values
+    valid_ix = processed[processed['editType'] == 'VALID'].index.values
     processed.loc[deletions_ix, 'Deleted Beat'] = 1
     processed.loc[additions_ix, 'Added Beat'] = 1
+    processed.loc[valid_ix, 'Validated Beat'] = 1
     processed.loc[deletions_ix, 'Edited Beat'] = np.nan
     if 'Unusable' in processed.columns:
         processed.loc[processed['Unusable'].eq(1), 'Edited Beat'] = np.nan
     processed.loc[additions_ix, 'Edited Beat'] = 1
+    if len(valid_ix) > 0 and 'Artifact' in processed.columns:
+        processed['Original Artifact'] = processed['Artifact']
+
     processed = processed.drop(columns = ['x', 'editType'], errors = 'ignore')
     return processed


### PR DESCRIPTION
This PR adds a "Mark Valid Beat" workflow and its associated UI elements to the Beat Editor to allow users to reclassify "Potential Artifact" beats as valid beats. It wires the new validation through the Dashboard so recomputed SQA metrics (artifact and missing beats) reflect the user's edits of validated beats.

### What's New
- New "Mark Valid Beat" toolbar button and a V keyboard shortcut
- Only "Potential Artifact" beats can be validated; clicking on a non-artifact point triggers a toast
- Validated beats render golden with a green outline
- New `'VALID'` edit type saved to the `_edited.json`
- Toolbar dividers separating the navigation / editing / file-action button groups (`ToolbarDivider` component)
- UI styling changes
- `physioview.process_beat_edits()` now records a `'Validated Beat'` column and, when beats have been validated, an `'Original Artifact'` column that preserves the pre-validation artifact flags
- On re-render, validated beats are excluded from the recomputed artifacts

### Screenshots
#### Before Changes
<img width="1419" height="636" alt="Screenshot 2026-07-08 at 11 44 54 PM" src="https://github.com/user-attachments/assets/d857f6ec-6325-4d06-bb6e-b272e62f7e4c" />

#### After Changes
<img width="1420" height="636" alt="Screenshot 2026-07-08 at 11 58 38 PM" src="https://github.com/user-attachments/assets/ee9834ca-2a60-423f-93eb-4f2a839799f0" />
